### PR TITLE
[xmlrpc]: don't forget the last string fragment, between the last quoted...

### DIFF
--- a/lib/xmlrpc.ml
+++ b/lib/xmlrpc.ml
@@ -51,6 +51,7 @@ let encode s =
 				  Buffer.add_string buf n;
 				  m := i + 1
 		done;
+		Buffer.add_substring buf s !m (n - !m);
 		Buffer.contents buf
 	end else
 		s


### PR DESCRIPTION
... character and the end.

Otherwise strings like '"hello' become '"'
