### PR TITLE
Fix an minor issue with Xmlrpc and make Jsonrpc and Xmlrpc more alike

### DIFF
--- a/lib/jsonrpc.ml
+++ b/lib/jsonrpc.ml
@@ -67,6 +67,11 @@ let to_string t =
 	to_buffer t buf;
 	Buffer.contents buf
 
+let to_a ~empty ~append t =
+	let buf = empty () in
+	to_fct t (fun s -> append buf s);
+	buf
+
 let new_id =
 	let count = ref 0L in
 	(fun () -> count := Int64.add 1L !count; !count)
@@ -79,21 +84,27 @@ let string_of_call call =
 	] in
 	to_string json
 
+let json_of_response response = 
+	if response.Rpc.success then
+		Dict [
+			"result", response.Rpc.contents;
+			"error", Null;
+			"id", Int 0L
+		]
+	else
+		Dict [
+			"result", Null;
+			"error", response.Rpc.contents;
+			"id", Int 0L
+		]
+			
 let string_of_response response =
-	let json =
-		if response.Rpc.success then
-			Dict [
-				"result", response.Rpc.contents;
-				"error", Null;
-				"id", Int 0L
-			]
-		else
-			Dict [
-				"result", Null;
-				"error", response.Rpc.contents;
-				"id", Int 0L
-			] in
+	let json = json_of_response response in
 	to_string json
+
+let a_of_response ~empty ~append response =
+	let json = json_of_response response in
+	to_a ~empty ~append json
 
 type error =
 	| Unexpected_char of int * char * (* json type *) string
@@ -483,6 +494,8 @@ end
 let of_fct = Parser.of_stream
 
 let of_string = Parser.of_string
+let of_a ~next_char b =
+	Parser.of_stream (fun () -> next_char b)
 
 exception Malformed_method_request of string
 exception Malformed_method_response of string

--- a/lib/jsonrpc.mli
+++ b/lib/jsonrpc.mli
@@ -18,6 +18,9 @@ val of_string : string -> Rpc.t
 val to_fct : Rpc.t -> (string -> unit) -> unit
 val of_fct : (unit -> char) -> Rpc.t
 
+val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a
+val of_a : next_char:('a  -> char) -> 'a -> Rpc.t
+
 val string_of_call: Rpc.call -> string
 val call_of_string: string -> Rpc.call
 
@@ -25,4 +28,5 @@ val string_of_response: Rpc.response -> string
 val response_of_string: string -> Rpc.response
 val response_of_in_channel : in_channel -> Rpc.response
 
-
+val a_of_response : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a
+ 

--- a/lib/xmlrpc.ml
+++ b/lib/xmlrpc.ml
@@ -135,7 +135,7 @@ let add_response add response =
 	else
 		Dict [ "Status", String "Failure"; "ErrorDescription", response.contents ] in
 	add "<?xml version=\"1.0\"?><methodResponse><params><param>";
-	add (to_string v);
+	to_a ~empty:(fun () -> ()) ~append:(fun _ s -> add s) v;
 	add "</param></params></methodResponse>"
 
 let string_of_response response =


### PR DESCRIPTION
Jsonrpc already had to_fct whereas Xmlrpc had to_a, both quite similar.
I've opted to implement to_a in Jsonrpc, mostly because in xen-api-libs
we didn't have the to_fct exposed in our copy of Jsonrpc.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
