### PR TITLE
Add the Int32 type to rpc-light.

### DIFF
--- a/lib/jsonrpc.ml
+++ b/lib/jsonrpc.ml
@@ -44,6 +44,7 @@ let escape_string s =
 let rec to_fct t f =
 	match t with
 	| Int i    -> f (Printf.sprintf "%Ld" i)
+	| Int32 i  -> f (Printf.sprintf "%ld" i)
 	| Bool b   -> f (string_of_bool b)
 	| Float r  -> f (Printf.sprintf "%f" r)
 	| String s -> f (escape_string s)

--- a/lib/rpc.ml
+++ b/lib/rpc.ml
@@ -19,6 +19,7 @@ let lower = String.lowercase
 
 type t =
 	| Int of int64
+	| Int32 of int32
 	| Bool of bool
 	| Float of float
 	| String of string
@@ -34,6 +35,7 @@ open Printf
 let map_strings sep fn l = String.concat sep (List.map fn l)
 let rec to_string t = match t with
 	| Int i      -> sprintf "I(%Li)" i
+	| Int32 i    -> sprintf "I32(%li)" i
 	| Bool b     -> sprintf "B(%b)" b
 	| Float f    -> sprintf "F(%g)" f
 	| String s   -> sprintf "S(%s)" s

--- a/lib/rpc.mli
+++ b/lib/rpc.mli
@@ -16,6 +16,7 @@
 
 type t =
     Int of int64
+  | Int32 of int32
   | Bool of bool
   | Float of float
   | String of string

--- a/lib/xmlrpc.ml
+++ b/lib/xmlrpc.ml
@@ -65,6 +65,11 @@ let rec add_value f = function
 		f (Int64.to_string i);
 		f "</value>"
 
+	| Int32 i ->
+		f "<value><i4>";
+		f (Int32.to_string i);
+		f "</i4></value>"
+
 	| Bool b ->
 		f "<value><boolean>";
 		f (if b then "1" else "0");


### PR DESCRIPTION
Note that the autogen code never generates this, it's purely
intended for places where for whatever reason you really need to
marshal an int32 into an xmlrpc <i4> tag.

Signed-off-by: Jon Ludlam jonathan.ludlam@eu.citrix.com
