### PR TITLE
Turn debug printing off by default

### DIFF
--- a/lib/rpc.ml
+++ b/lib/rpc.ml
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 
-let debug = ref true
+let debug = ref false
 let set_debug x = debug := x
 let get_debug () = !debug
 let lower = String.lowercase


### PR DESCRIPTION
Otherwise stderr is spammed with harmless runtime error prints,
since we generate code like

  try
    ..
  with Runtime_error(_, _) ->
    (\* that's ok, do something else *)

Signed-off-by: David Scott dave.scott@eu.citrix.com
