### PR TITLE
Make the dependency on js_of_ocaml optional

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,7 +3,9 @@ dependencies:
 * ocamlfind
 * type-conv
 * xmlm
-* ocaml-js
+
+optional dependencies:
+* js_of_ocaml
 
 instructions:
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 .PHONY: all install
 
+HAVE_JS_OF_OCAML ?= $(shell if ocamlfind query js_of_ocaml > /dev/null 2>&1; then echo true; else echo false; fi)
+
 all:
 	cd lib && $(MAKE) all
+ifeq ($(HAVE_JS_OF_OCAML),true)
+	cd lib && $(MAKE) all-js
+endif
 
 install:
+ifeq ($(HAVE_JS_OF_OCAML),true)
+	cd lib && $(MAKE) install-js
+else
 	cd lib && $(MAKE) install
+endif
 
 uninstall:
 	cd lib && $(MAKE) uninstall

--- a/lib/META
+++ b/lib/META
@@ -47,4 +47,6 @@ package "js" (
   description = "Javascript/browser connection handling"
   requires = "rpclib.core"
   archive(byte) = "rpc_client_js.cma"
+  exists_if = "rpc_client_js.cma"
+
 )

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,9 +1,13 @@
 OCAMLC = ocamlfind ocamlc
 OCAMLOPT = ocamlfind ocamlopt
 OCAMLFLAGS = -annot -g
-PACKS = xmlm,lwt,js_of_ocaml,js_of_ocaml.syntax
+PACKS = xmlm,lwt
+PACKS_JS = js_of_ocaml,js_of_ocaml.syntax
 
 ICAMLP4 = -I $(shell ocamlfind query camlp4) \
+	-I $(shell ocamlfind query type_conv) 
+
+ICAMLP4_JS = -I $(shell ocamlfind query camlp4) \
 	-I $(shell ocamlfind query type_conv)    \
 	-I $(shell ocamlfind query js_of_ocaml)  \
 	-I $(shell ocamlfind query lwt)
@@ -14,12 +18,16 @@ TARGETS = \
 	pa_rpc.cma idl.cma \
 	xmlrpc.cmi xmlrpc.cmo xmlrpc.o xmlrpc.cmx \
 	jsonrpc.cmi jsonrpc.cmo jsonrpc.o jsonrpc.cmx \
-	rpc_client.cmi rpc_client.cmo rpc_client.o rpc_client.cmx \
+	rpc_client.cmi rpc_client.cmo rpc_client.o rpc_client.cmx
+TARGETS_JS = \
 	rpc_client_js.cmi rpc_client_js.cmo rpc_client_js_helper.cmo \
 	rpc_client.cmo rpc_client_js.cma
 
-.PHONY: all clean
+
+.PHONY: all all-js clean clean-js
 all: $(TARGETS)
+
+all-js:$(TARGETS_JS)
 
 pa_module_conv.cmo: pa_module_conv.ml
 	$(OCAMLC) $(OCAMLFLAGS) -c -package camlp4 -pp "camlp4orf" -I $(shell ocamlfind query camlp4) -o $@ $^
@@ -40,13 +48,13 @@ p4_idl.cmo: p4_idl.ml p4_rpc.cmo
 	$(OCAMLC) $(OCAMLFLAGS) -c -package camlp4,type_conv -pp "camlp4orf" $(ICAMLP4) $@ $<
 
 rpc_client_js.cma: rpc_client_js_helper.cmo rpc_client_js.cmo
-	$(OCAMLC) $(OCAMLFLAGS) -package $(PACKS) -syntax camlp4o $(ICAMLP4) -a -o $@ $^
+	$(OCAMLC) $(OCAMLFLAGS) -package $(PACKS_JS) -syntax camlp4o $(ICAMLP4_JS) -a -o $@ $^
 
 rpc_client_js_helper.cmo: rpc_client_js_helper.ml
-	$(OCAMLC) $(OCAMLFLAGS) -package $(PACKS) -syntax camlp4o $(ICAMLP4) -c $@ $<
+	$(OCAMLC) $(OCAMLFLAGS) -package $(PACKS_JS) -syntax camlp4o $(ICAMLP4_JS) -c $@ $<
 
 rpc_client_js.cmo: rpc_client_js.ml rpc_client_js_helper.cmo 
-	$(OCAMLC) $(OCAMLFLAGS) -package $(PACKS) -syntax camlp4o $(ICAMLP4) -c $@ $<
+	$(OCAMLC) $(OCAMLFLAGS) -package $(PACKS_JS) -syntax camlp4o $(ICAMLP4_JS) -c $@ $<
 
 %.o %.cmx: %.ml
 	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS) -c -o $@ $<
@@ -57,10 +65,14 @@ rpc_client_js.cmo: rpc_client_js.ml rpc_client_js_helper.cmo
 %.cmi: %.mli %.ml
 	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS) -c -o $@ $<
 
-.PHONY: install
+.PHONY: install install-js
 install: INSTALL_PATH = $(DESTDIR)$(shell ocamlfind printconf destdir)
 install: all
 	ocamlfind install -destdir "$(INSTALL_PATH)" rpclib META $(TARGETS)
+
+install-js: INSTALL_PATH = $(DESTDIR)$(shell ocamlfind printconf destdir)
+install-js: all
+	ocamlfind install -destdir "$(INSTALL_PATH)" rpclib META $(TARGETS) $(TARGETS_JS)
 
 .PHONY: uninstall
 uninstall:


### PR DESCRIPTION
We only build the rpclib.js sub-package (which can only be
used if js_of_ocaml is installed) only if js_of_ocaml is
installed.

This makes it easier for the xapi-project, since it doesn't
need to package js_of_ocaml.

Signed-off-by: David Scott dave.scott@citrix.com
