### PR TITLE
fix invalid printf format

### DIFF
--- a/lib/xmlrpc.ml
+++ b/lib/xmlrpc.ml
@@ -81,7 +81,7 @@ let rec add_value f = function
   | Float d ->
     f "<value><double>";
     (* NB: "%g" loses a lot of precision (e.g. resulting in "1.32621e+09") *)
-    f (Printf.sprintf "%0.16g" d);
+    f (Printf.sprintf "%.16g" d);
     f "</double></value>"
 
   | String s ->


### PR DESCRIPTION
There are some format strings that are "invalid" in the ocaml-rpc sources.

In general, invalid formats are nonsensical format strings that were accepted in OCaml 4.01.0 and earlier, but whose semantics is unspecified. They are still accepted by the new Printf implementation of OCaml 4.02.0 but in some cases with different semantics, and they will be statically rejected by OCaml 4.03.0.

You can check for them in OCaml 4.02.0 with the flag -strict-formats.

In the case of ocaml-rpc, I think the behavior has not changed between 4.01.0 and 4.02.0. The only invalid format is "%0.16g". This is considered invalid beause it specifies a padding character (with the flag 0), but no minimum field width (no number before the dot) so there will never be padding. Even though the behaviour has not changed, you should take the opportunity to review the code and fix the format. The patch changes it to "%.16g", which keeps the behaviour unchanged, but that might still be wrong.
