### PR TITLE
Add support for JSON-RPC v2

### DIFF
--- a/lib/jsonrpc.mli
+++ b/lib/jsonrpc.mli
@@ -24,11 +24,13 @@ val of_fct : (unit -> char) -> Rpc.t
 val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a
 val of_a : next_char:('a  -> char) -> 'a -> Rpc.t
 
-val string_of_call: Rpc.call -> string
+type version = V1 | V2
+
+val string_of_call: ?version:version -> Rpc.call -> string
 val call_of_string: string -> Rpc.call
 
-val string_of_response: Rpc.response -> string
+val string_of_response: ?version:version -> Rpc.response -> string
 val response_of_string: string -> Rpc.response
 val response_of_in_channel : in_channel -> Rpc.response
 
-val a_of_response : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a
+val a_of_response : ?version:version -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a


### PR DESCRIPTION
This adds a `version` argument to `Jsonrpc.string_of_{call;response}`,
and updates the `of_string` functions accordingly.

The main changes compared to JSON-RPC v1 are:
1. And added version field: `{jsonrpc: "2.0"}`.
2. Support for named parameters in requests:
   `params: {"name1": "value2", "name2", "value2"}`.
3. Responses have a `result` OR an `error`, but not both.

Regarding (2), since the `RPC.call` type defines its `params` as a `t list`, it
does not have support for named parameters in the type itself. Positional
params are still treated as in V1, by putting them in an array (`params:
[value1, value2]`). To overcome this, we assume that if the first parameter in
this list has an `Rpc.Dict` type, and this is the only parameter, that the
dictionary contains named parameters.

Fixes #32

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>