### PR TITLE
Port to ocaml 4.03 (backward compatible with 4.02)

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,4 @@
-PKG ppx_deriving ppx_tools rpclib ppx_tools.metaquot result cow cmdliner rresult lwt async oUnit ppx_deriving_rpc
+PKG ppx_deriving ppx_tools rpclib ppx_tools.metaquot result cow cmdliner rresult lwt async oUnit ppx_deriving_rpc cppo_ocamlbuild
 S ppx
 S lib
 S tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,13 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-opam.sh
 sudo: true
 env:
-  - OCAML_VERSION=4.02 PACKAGE=rpc
+    global:
+        - PACKAGE=rpc
+    matrix:
+        - OCAML_VERSION=4.02
+        - OCAML_VERSION=4.03
+        - OCAML_VERSION=4.04
+matrix:
+    fast_finish: true
+    allow_failures:
+        - env: OCAML_VERSION=4.04

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean:
 	make -C ppx_test clean
 	make -C tests clean
 	make -C example clean
-	rm -f setup.data setup.log setup.ml myocamlbuild.ml
+	rm -f setup.data setup.log setup.ml
 
 distclean:
 	$(SETUP) -distclean $(DISTCLEANFLAGS)

--- a/_oasis
+++ b/_oasis
@@ -117,6 +117,6 @@ Library rpc_client_js
   Path: js
   FindlibParent: rpclib
   Findlibname: js
-  BuildDepends: js_of_ocaml, js_of_ocaml.syntax
+  BuildDepends: js_of_ocaml, js_of_ocaml.ppx, rpclib.core
   Modules: Rpc_client_js, Rpc_client_js_helper
 

--- a/_oasis
+++ b/_oasis
@@ -47,13 +47,13 @@ Library cmdlinergen
   Modules: Cmdlinergen
   BuildDepends: rpclib.core, rpclib.json, cmdliner
 
-#Library htmlgen
-#  Path: lib
-#  CompiledObject: best
-#  FindlibParent: rpclib
-#  Findlibname: html
-#  Modules: Htmlgen
-#  BuildDepends: rpclib.core, cow
+Library htmlgen
+  Path: lib
+  CompiledObject: best
+  FindlibParent: rpclib
+  Findlibname: html
+  Modules: Htmlgen
+  BuildDepends: rpclib.core, cow
 
 Library markdowngen
   Path: lib

--- a/_oasis
+++ b/_oasis
@@ -1,4 +1,4 @@
-OASISFormat: 0.3
+OASISFormat: 0.4
 Name:        rpclib
 Version:     1.9.50
 Synopsis:    RPC library
@@ -6,6 +6,10 @@ Authors:     Thomas Gazagnaire, Jon Ludlam
 License:     ISC
 Plugins:     META(0.4)
 BuildTools:  ocamlbuild
+AlphaFeatures: ocamlbuild_more_args
+XOCamlbuildPluginTags: package(cppo_ocamlbuild)
+OCamlVersion: >= 4.02
+
 
 Flag js
   Description: build the JS client

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: ee457f80c439d0c8f96fdb5309c29d25)
+# DO NOT EDIT (digest: afcff56637e5433d562333c658c7ae78)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -22,43 +22,43 @@ true: annot, bin_annot
 "lib/json.cmxs": use_json
 # Library cmdlinergen
 "lib/cmdlinergen.cmxs": use_cmdlinergen
-<lib/*.ml{,i,y}>: pkg_cmdliner
+<lib/*.ml{,i,y}>: package(cmdliner)
 # Library markdowngen
 "lib/markdowngen.cmxs": use_markdowngen
 <lib/*.ml{,i,y}>: use_json
 # Library rpclib_lwt
 "lib/rpclib_lwt.cmxs": use_rpclib_lwt
-<lib/*.ml{,i,y}>: pkg_lwt
+<lib/*.ml{,i,y}>: package(lwt)
 # Library rpclib_async
 "lib/rpclib_async.cmxs": use_rpclib_async
-<lib/*.ml{,i,y}>: pkg_async
-<lib/*.ml{,i,y}>: pkg_threads
+<lib/*.ml{,i,y}>: package(async)
+<lib/*.ml{,i,y}>: package(threads)
 # Library rpclib_syntax
 "lib/rpclib_syntax.cmxs": use_rpclib_syntax
-<lib/*.ml{,i,y}>: pkg_type_conv
+<lib/*.ml{,i,y}>: package(type_conv)
 # Library rpclib_unix
 "lib/rpclib_unix.cmxs": use_rpclib_unix
 # Library rpclib
 "lib/rpclib.cmxs": use_rpclib
 # Library idl
 "lib/idl.cmxs": use_idl
-<lib/*.ml{,i,y}>: pkg_camlp4
-<lib/*.ml{,i,y}>: pkg_result
-<lib/*.ml{,i,y}>: pkg_rresult
-<lib/*.ml{,i,y}>: pkg_xmlm
+<lib/*.ml{,i,y}>: package(camlp4)
+<lib/*.ml{,i,y}>: package(result)
+<lib/*.ml{,i,y}>: package(rresult)
+<lib/*.ml{,i,y}>: package(xmlm)
 <lib/*.ml{,i,y}>: use_rpclib
 <lib/*.ml{,i,y}>: use_rpclib_core
 <lib/*.ml{,i,y}>: use_xml
 # Library ppx_deriving_rpc
 "ppx/ppx_deriving_rpc.cmxs": use_ppx_deriving_rpc
-<ppx/*.ml{,i,y}>: pkg_compiler-libs.common
-<ppx/*.ml{,i,y}>: pkg_ppx_deriving
-<ppx/*.ml{,i,y}>: pkg_ppx_deriving.api
-<ppx/*.ml{,i,y}>: pkg_ppx_tools.metaquot
+<ppx/*.ml{,i,y}>: package(compiler-libs.common)
+<ppx/*.ml{,i,y}>: package(ppx_deriving)
+<ppx/*.ml{,i,y}>: package(ppx_deriving.api)
+<ppx/*.ml{,i,y}>: package(ppx_tools.metaquot)
 # Library rpc_client_js
 "js/rpc_client_js.cmxs": use_rpc_client_js
-<js/*.ml{,i,y}>: pkg_js_of_ocaml
-<js/*.ml{,i,y}>: pkg_js_of_ocaml.syntax
+<js/*.ml{,i,y}>: package(js_of_ocaml)
+<js/*.ml{,i,y}>: package(js_of_ocaml.syntax)
 # OASIS_STOP
 <lib/pa_rpc.ml>: pp(camlp4orf)
 <lib/p4_rpc.ml>: pp(camlp4orf)
@@ -68,3 +68,5 @@ true: annot, bin_annot
 <example/*>: not_hygienic
 <tests/*>: not_hygienic
 <ppx_test/*>: not_hygienic
+<ppx/*>: cppo_V_OCAML
+true: thread

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: afcff56637e5433d562333c658c7ae78)
+# DO NOT EDIT (digest: 5c799cfbd606cea83d7a3859438a5bee)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -58,7 +58,10 @@ true: annot, bin_annot
 # Library rpc_client_js
 "js/rpc_client_js.cmxs": use_rpc_client_js
 <js/*.ml{,i,y}>: package(js_of_ocaml)
-<js/*.ml{,i,y}>: package(js_of_ocaml.syntax)
+<js/*.ml{,i,y}>: package(js_of_ocaml.ppx)
+<js/*.ml{,i,y}>: package(result)
+<js/*.ml{,i,y}>: package(rresult)
+<js/*.ml{,i,y}>: use_rpclib_core
 # OASIS_STOP
 <lib/pa_rpc.ml>: pp(camlp4orf)
 <lib/p4_rpc.ml>: pp(camlp4orf)
@@ -69,4 +72,4 @@ true: annot, bin_annot
 <tests/*>: not_hygienic
 <ppx_test/*>: not_hygienic
 <ppx/*>: cppo_V_OCAML
-true: thread
+<true>: thread

--- a/_tags
+++ b/_tags
@@ -1,5 +1,5 @@
 # OASIS_START
-# DO NOT EDIT (digest: 5c799cfbd606cea83d7a3859438a5bee)
+# DO NOT EDIT (digest: d2c75c15f67ddb5042f9589ffc4924d5)
 # Ignore VCS directories, you can use the same kind of rule outside
 # OASIS_START/STOP if you want to exclude directories that contains
 # useless stuff for the build process
@@ -23,6 +23,9 @@ true: annot, bin_annot
 # Library cmdlinergen
 "lib/cmdlinergen.cmxs": use_cmdlinergen
 <lib/*.ml{,i,y}>: package(cmdliner)
+# Library htmlgen
+"lib/htmlgen.cmxs": use_htmlgen
+<lib/*.ml{,i,y}>: package(cow)
 # Library markdowngen
 "lib/markdowngen.cmxs": use_markdowngen
 <lib/*.ml{,i,y}>: use_json

--- a/example/example2_server.ml
+++ b/example/example2_server.ml
@@ -81,7 +81,7 @@ let start_server () =
   Server.diagnostics diagnostics;
   Server.test test;
 
-  let rpc_fn = Server.implementation in
+  let rpc_fn = server Server.implementation in
 
   let process x =
     Jsonrpc.string_of_response (rpc_fn (Jsonrpc.call_of_string x)) in

--- a/js/rpc_client_js.ml
+++ b/js/rpc_client_js.ml
@@ -25,18 +25,18 @@ let do_rpc enc dec content_type ~url call =
   let (res, w) = Lwt.task () in
   let req = XmlHttpRequest.create () in
 
-  req##_open (Js.string method_, Js.string url, Js._true);
-  req##setRequestHeader (Js.string "Content-type", Js.string content_type);
-  req##onreadystatechange <- Js.wrap_callback
+  req##_open (Js.string method_) (Js.string url) Js._true;
+  req##setRequestHeader (Js.string "Content-type") (Js.string content_type);
+  req##.onreadystatechange := Js.wrap_callback
       (fun _ ->
-         (match req##readyState with
+         (match req##.readyState with
           | XmlHttpRequest.DONE ->
-            Lwt.wakeup w (dec (Js.to_string req##responseText))
+            Lwt.wakeup w (dec (Js.to_string req##.responseText))
           | _ -> ()));
 
   req##send (Js.some (Js.string contents));
 
-  Lwt.on_cancel res (fun () -> req##abort ()) ;
+  Lwt.on_cancel res (fun () -> req##abort);
   res
 
 let do_xml_rpc = do_rpc Xmlrpc.string_of_call Xmlrpc.response_of_string "text/xml"

--- a/js/rpc_client_js_helper.ml
+++ b/js/rpc_client_js_helper.ml
@@ -96,7 +96,7 @@ let response_of_string str =
   | Rpc.Dict d ->
     let result = get "result" d in
     let error = get "error" d in
-    let (_:int64) = try match get "id" d with Rpc.Int i -> i | Rpc.String s -> Int64.of_string s with _ -> 
+    let (_:int64) = try match get "id" d with Rpc.Int i -> i | Rpc.String s -> Int64.of_string s | _ -> failwith "inconsistent input" with _ -> 
       Firebug.console##log (Js.string (Printf.sprintf "Weirdness: %s" (Rpc.to_string (get "id" d))));
       raise (Malformed_method_response "id") in
     begin match result, error with

--- a/lib/htmlgen.ml
+++ b/lib/htmlgen.ml
@@ -41,7 +41,8 @@ let of_args args =
           tag "td" (tag "code" (string name));
           tag "td" (string direction);
           tag "td" (tag "code" (list ty));
-          tag "td" (string description)])
+          tag "td" (string (String.concat " " description))
+      ])
   in
   tag "table" ~attrs:["width","100%"]
     (list [
@@ -82,7 +83,8 @@ let of_struct_fields : 'a boxed_field list -> Cow.Html.t = fun all ->
       (list
          [ tag "td" (tag "pre" (string f.fname));
            tag "td" (tag "pre" (string (String.concat "" ty)));
-           tag "td" (string f.fdescription) ])
+           tag "td" (string (String.concat " " f.fdescription))
+    ])
   in
   tag "table" ~attrs:["width","100%"]
     (list [ tag "thead"
@@ -102,7 +104,8 @@ let of_variant_tags : 'a boxed_tag list -> Cow.Html.t = fun all ->
       (list
          [ tag "td" (tag "pre" (string t.tname));
            tag "td" (tag "pre" (string (String.concat "" ty)));
-           tag "td" (string t.tdescription) ])
+           tag "td" (string (String.concat " " t.tdescription))
+    ])
   in
   tag "table" ~attrs:["width","100%"]
     (list [ tag "thead"
@@ -123,7 +126,8 @@ let of_type_decl i_opt (BoxedDef t) =
   let description = t.description in
   let common =
     [ h4 ~id:anchor (string (Printf.sprintf "type %s = %s" name defn));
-      p (string description) ]
+      p (string (String.concat " " description))
+    ]
   in
   let rest = match t.ty with
     | Struct structure ->
@@ -175,8 +179,8 @@ let of_method is i (Codegen.BoxedFunction m) =
   let name = m.Method.name in
   let description = m.Method.description in
   [ h3 ~id:anchor (string name);
-    p (string description) ]
-  @ tabs_of is i m
+    p (string (String.concat " " description))
+  ] @ tabs_of is i m
 
 
 let of_interface is i =
@@ -184,8 +188,8 @@ let of_interface is i =
   let anchor = "a-" ^ name in
   let description = i.Interface.details.Idl.Interface.description in
   [ h2 ~id:anchor (string name);
-    p (string description) ] @
-  List.concat (List.map (of_method is i) i.Interface.methods)
+    p (string (String.concat " " description))
+  ] @ List.concat (List.map (of_method is i) i.Interface.methods)
 
 (*
 let of_exception ts =
@@ -229,7 +233,7 @@ let of_interfaces x =
            (list
               ([
                 h1 (string name);
-                p (string description);
+                p (string (String.concat " " description));
               ] @
                 List.concat (List.map (of_type_decl None) x.Interfaces.type_decls)
                 @

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -1,0 +1,8 @@
+(* OASIS_START *)
+(* OASIS_STOP *)
+let () =
+  Ocamlbuild_plugin.dispatch
+    (fun hook ->
+      Ocamlbuild_cppo.dispatcher hook ;
+      dispatch_default hook;
+    )

--- a/opam
+++ b/opam
@@ -21,6 +21,7 @@ remove: [
 ]
 depends: [
   "oasis" {build}
+  "cppo"  {build}
   "ocamlfind"
   "type_conv" {>= "108.07.01"}
   "ppx_deriving"

--- a/opam
+++ b/opam
@@ -19,6 +19,10 @@ remove: [
   ["ocamlfind" "remove" "rpclib"]
   ["ocamlfind" "remove" "ppx_deriving_rpc"]
 ]
+build-test: [
+    [make]
+    [make "test"]
+]
 depends: [
   "oasis" {build}
   "cppo"  {build}

--- a/ppx/ppx_deriving_rpc.cppo.ml
+++ b/ppx/ppx_deriving_rpc.cppo.ml
@@ -154,7 +154,7 @@ module Of_rpc = struct
               raise_errorf ~loc:ptyp_loc "%s cannot be derived for %s"
                 deriver (Ppx_deriving.string_of_core_type typ))
       and inherits_case =
-        let toplevel_typ = typ in
+        (*let toplevel_typ = typ in*)
         inherits |>
         List.map (function Rinherit typ -> typ | _ -> assert false) |>
         List.fold_left (fun expr typ ->

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,13 @@ OCAMLC = ocamlfind ocamlc
 OCAMLOPT = ocamlfind ocamlopt
 OCAMLFLAGS = -annot -g
 
-PACKS = rpclib,rpclib.json,ppx_deriving_rpc,unix
+PACKS = unix,rresult,xmlm
+RPC = -I ../_build/lib
+RPCLINK = rpclib.cmxa rpclib_core.cmxa json.cmxa xml.cmxa
+
+CAMLP4 = camlp4o $(shell ocamlfind query type_conv -r -format "-I %d %a" -predicates syntax,preprocessor) $(RPC) rpclib_syntax.cma
+PPXOPTS=-package ppx_deriving -ppxopt ppx_deriving,../_build/ppx/ppx_deriving_rpc.cma
+
 EXAMPLES = \
 	all_types \
 	phantom \
@@ -28,44 +34,44 @@ all: $(EXECS)
 	./$?
 
 client.opt: idl_test.cmx idl_test.cmi client.cmx
-	$(OCAMLOPT) -linkpkg -package $(PACKS) -o $@ idl_test.cmx client.cmx
+	$(OCAMLOPT) -linkpkg -package $(PACKS) $(RPC) $(RPCLINK) -o $@ idl_test.cmx client.cmx
 
 client_lwt.opt: idl_test.cmx idl_test.cmi client_lwt.cmx
-	$(OCAMLOPT) -linkpkg -package $(PACKS),lwt,lwt.unix,rpclib.lwt -o $@ idl_test.cmx client_lwt.cmx
+	$(OCAMLOPT) -linkpkg -package $(PACKS),lwt,lwt.unix $(RPC) $(RPCLINK) rpclib_lwt.cmxa -o $@ idl_test.cmx client_lwt.cmx
 
 idl_test.cmx: idl_test.ml idl_test.cmi
-	$(OCAMLOPT) -package $(PACKS),rpclib.idl -syntax camlp4o -c -o $@ $<
+	$(OCAMLOPT) -package $(PACKS) $(RPC) $(RPCLINK) idl.cmxa -pp "camlp4o $(RPC) idl.cma" -c -o $@ $<
 
 client_lwt_new.opt: client_lwt_new.cmx
-	$(OCAMLOPT) -linkpkg -package $(PACKS),lwt,lwt.unix,rpclib.lwt -o $@ client_lwt_new.cmx
+	$(OCAMLOPT) -linkpkg -package $(PACKS),lwt,lwt.unix $(RPC) $(RPCLINK) rpclib_lwt.cmxa -o $@ client_lwt_new.cmx
 
 client_async_new.opt: client_async_new.cmx
-	$(OCAMLOPT) -linkpkg -thread -package $(PACKS),rpclib.async -o $@ client_async_new.cmx
+	$(OCAMLOPT) -linkpkg -thread -package $(PACKS),async $(RPC) $(RPCLINK) rpclib_async.cmxa -o $@ client_async_new.cmx
 
 %.opt: %.cmx
-	$(OCAMLOPT) -linkpkg -package $(PACKS) -o $@ $<
+	$(OCAMLOPT) -linkpkg -package $(PACKS) $(RPC) $(RPCLINK) -o $@ $<
 
 client_lwt.cmx: client_lwt.ml
-	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS),lwt,lwt.unix,rpclib.lwt -c -o $@ $<
+	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS),lwt,lwt.unix $(RPC) $(RPCLINK) rpclib_lwt.cmxa -c -o $@ $<
 
 client_lwt_new.cmx: client_lwt_new.ml
-	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS),lwt,lwt.unix,rpclib.lwt -c -o $@ $<
+	$(OCAMLOPT) $(PPXOPTS) $(OCAMLFLAGS) -package $(PACKS),lwt,lwt.unix $(RPC) $(RPCLINK) rpclib_lwt.cmxa -c -o $@ $<
 
 client_async_new.cmx: client_async_new.ml
-	$(OCAMLOPT) $(OCAMLFLAGS) -package threads,$(PACKS),async -thread -c -o $@ $<
+	$(OCAMLOPT) $(PPXOPTS) $(OCAMLFLAGS) -package threads,$(PACKS),async $(RPC) $(RPCLINK) -thread -c -o $@ $<
 
 %.cmx: %.ml
-	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS),rpclib.syntax -syntax camlp4o -c -o $@ $<
+	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS) $(RPC) $(RPCLINK) -pp "$(CAMLP4)" -c -o $@ $<
 
 %.cmi: %.mli
-	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS),rpclib.syntax -syntax camlp4o -c -o $@ $<
+	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS) $(RPC) $(RPCLINK) -pp "$(CAMLP4)" -c -o $@ $<
 
 %_gen: %.ml
-	camlp4o $(shell ocamlfind query rpclib.syntax -r -format "-I %d %a" -predicates syntax,preprocessor) $< -printer o > $@.ml
-	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS) -c -o $@ $@.ml
+	$(CAMLP4) $< -printer o > $@.ml
+	$(OCAMLOPT) $(OCAMLFLAGS) -package $(PACKS) $(RPC) $(RPCLINK) -c -o $@ $@.ml
 
 idl_test_gen.ml: idl_test.ml
-	camlp4o $(shell ocamlfind query rpclib.idl -r -format "-I %d %a" -predicates syntax,preprocessor) $< -printer o > $@
+	camlp4o $(RPC) idl.cma  $< -printer o > $@
 
 
 clean:


### PR DESCRIPTION
Use `cppo` to port the library to more recent version of the compiler. This has been tested with `4.02.3` and `4.03`. Due to the deprecation of `String.capitalize` and `String.lowercase` in `4.03`, this might not yet work on `4.04`.

I currently only want to extend the compatibility while we wait for `ocaml-versioned-parsetree` and the new `ppx_deriving` interface to stabilise. This will allow us to start checking what in xapi/xenserver fails if we use a newer compiler (current first issues can be seen already at https://travis-ci.org/mseri/xs-opam/builds/229982632 and give us a starting point to start the port of our libraries).

If there is no objection, the further plan will be to port it to `jbuilder` and `ocaml-versioned-parsetree` (in fact, this PR is a backport of my `jbuilder` branch with the necessary adjustments).

EDIT: according to the new tests this works also for `4.04`.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>