### PR TITLE
ppx: remove deprecation warning on `ocaml >= 4.03.0`

### DIFF
--- a/_tags
+++ b/_tags
@@ -75,4 +75,5 @@ true: annot, bin_annot
 <tests/*>: not_hygienic
 <ppx_test/*>: not_hygienic
 <ppx/*>: cppo_V_OCAML
+<ppx/*>: cppo_n
 <true>: thread

--- a/ppx/ppx_deriving_rpcty.cppo.ml
+++ b/ppx/ppx_deriving_rpcty.cppo.ml
@@ -1,8 +1,10 @@
 #if OCAML_VERSION < (4, 03, 0)
     #define Pconst_string Const_string
     #define Pcstr_tuple(x) x
+    #define lowercase String.lowercase
+#else
+    #define lowercase String.lowercase_ascii
 #endif
-
 
 open Longident
 open Asttypes
@@ -169,13 +171,13 @@ module Typ_of = struct
         let cases =
           constrs |> List.map (fun { pcd_name = { txt = name }; pcd_args; pcd_attributes } ->
               let rpc_name = attr_name name pcd_attributes in
-              let lower_rpc_name = String.lowercase rpc_name in
+              let lower_rpc_name = lowercase rpc_name in
               let typs = match pcd_args with
               | Pcstr_tuple(typs) -> typs
 #if OCAML_VERSION >= (4, 03, 0)
               | Pcstr_record _ ->
                 raise_errorf "%s: record variants are not supported" deriver
-#endif        
+#endif
               in
               let contents = match typs with
                 | [] -> [%expr Unit]
@@ -206,7 +208,7 @@ module Typ_of = struct
                          (match default_case with
                          | None -> [%expr Rresult.R.error_msg (Printf.sprintf "Unknown tag '%s'" s)]
                          | Some d -> [%expr Result.Ok [%e d]])] in
-        let vconstructor = [%expr fun s' t -> let s = String.lowercase s' in [%e Exp.match_ (evar "s") ((List.map snd cases) @ default)]] in
+        let vconstructor = [%expr fun s' t -> let s = lowercase s' in [%e Exp.match_ (evar "s") ((List.map snd cases) @ default)]] in
         [ Vb.mk (pvar typ_of_lid) (wrap_runtime (polymorphize (
               [%expr Variant ({
                   variants=([%e list (List.map fst cases)]);


### PR DESCRIPTION
This fixes an unwelcome series of deprecation warning when using `[@deriving rpc]` on `ocaml >= 4.03.0`.
In particular fixed the compilation of `message-switch` mentioned in the comments of a previous pr.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>