### PR TITLE
Fix the build on the Mac

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -95,6 +95,7 @@ Library rpclib_unix
 Library rpclib
   Path: lib
   FindlibName: rpclib
+  Modules: Rpc_empty_module
   BuildDepends: rpclib.xml
 
 Library idl

--- a/lib/rpc_empty_module.ml
+++ b/lib/rpc_empty_module.ml
@@ -1,0 +1,3 @@
+(* THe clang toolchain doesn't like archives with no elements,
+ * see https://github.com/mirage/ocaml-rpc/issues/44
+ *)


### PR DESCRIPTION
The clang toolchain doesn't like building an archive with no members:

```
+ /Users/djs/.opam/system/bin/ocamlfind ocamlopt -a -o lib/rpclib.cmxa
ar: no archive members specified
usage:  ar -d [-TLsv] archive file ...
	ar -m [-TLsv] archive file ...
	ar -m [-abiTLsv] position archive file ...
	ar -p [-TLsv] archive [file ...]
	ar -q [-cTLsv] archive file ...
	ar -r [-cuTLsv] archive file ...
	ar -r [-abciuTLsv] position archive file ...
	ar -t [-TLsv] archive [file ...]
	ar -x [-ouTLsv] archive [file ...]
File "_none_", line 1:
Error: Error while creating the library lib/rpclib.a
```

This patch works around this by creating a single empty module with
only a comment explaining why it exists.

Fixes #44

Signed-off-by: David Scott <dave@recoil.org>