### PR TITLE
Delay eval of Cmdliner terms so any globals can be initialised first

### DIFF
--- a/lib/cmdlinergen.ml
+++ b/lib/cmdlinergen.ml
@@ -2,7 +2,7 @@ open Idl
 
 module Gen () = struct
   type implementation = unit -> ((Rpc.call -> Rpc.response) ->
-                      unit Cmdliner.Term.t * Cmdliner.Term.info) list
+                      (unit -> unit) Cmdliner.Term.t * Cmdliner.Term.info) list
 
   type ('a,'b) comp = ('a,'b) Result.result
   type 'a rpcfn = Rpc.call -> Rpc.response
@@ -111,7 +111,7 @@ module Gen () = struct
   let declare name desc_list ty =
     let generate rpc =
       let wire_name = Idl.get_wire_name !description name in
-      let rec inner : type b. (((string * Rpc.t) list) * Rpc.t list) Cmdliner.Term.t -> b fn -> unit Cmdliner.Term.t = fun cur f ->
+      let rec inner : type b. (((string * Rpc.t) list) * Rpc.t list) Cmdliner.Term.t -> b fn -> (unit -> unit) Cmdliner.Term.t = fun cur f ->
         match f with
         | Function (t, f) -> begin
           let term = term_of_param t in
@@ -132,7 +132,7 @@ module Gen () = struct
             | x -> Printf.printf "%s\n" (Rpc.to_string x);
               ()
           in
-          Cmdliner.Term.(const (fun args -> run args) $ cur)
+          Cmdliner.Term.(const (fun args () -> run args) $ cur)
       in
       let doc = String.concat " " desc_list in
       pos := 0;


### PR DESCRIPTION
Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>