### PR TITLE
New function to retrieve the version of JSON-RPC alongside the Rpc.ca…

### DIFF
--- a/lib/jsonrpc.ml
+++ b/lib/jsonrpc.ml
@@ -106,20 +106,20 @@ let string_of_call ?(version=V1) call =
   in
   to_string json
 
-let json_of_response version response =
+let json_of_response ?(id=Int 0L) version response =
   if response.Rpc.success then
     match version with
     | V1 ->
       Dict [
         "result", response.Rpc.contents;
         "error", Null;
-        "id", Int 0L
+        "id", id
       ]
     | V2 ->
       Dict [
         "jsonrpc", String "2.0";
         "result", response.Rpc.contents;
-        "id", Int 0L
+        "id", id
       ]
   else
     match version with
@@ -127,25 +127,25 @@ let json_of_response version response =
       Dict [
         "result", Null;
         "error", response.Rpc.contents;
-        "id", Int 0L
+        "id", id
       ]
     | V2 ->
       Dict [
         "jsonrpc", String "2.0";
         "error", response.Rpc.contents;
-        "id", Int 0L
+        "id", id
       ]
 
 let json_of_error_object ?(data=None) code message =
   let data_json = match data with Some d -> ["data", d] | None -> [] in
   Dict ([ "code", Int code; "message", String message; ] @ data_json)
 
-let string_of_response ?(version=V1) response =
-  let json = json_of_response version response in
+let string_of_response ?(id=Int 0L) ?(version=V1) response =
+  let json = json_of_response ~id version response in
   to_string json
 
-let a_of_response ?(version=V1) ~empty ~append response =
-  let json = json_of_response version response in
+let a_of_response ?(id=Int 0L) ?(version=V1) ~empty ~append response =
+  let json = json_of_response ~id version response in
   to_a ~empty ~append json
 
 type error =
@@ -541,6 +541,7 @@ let of_a ~next_char b =
 
 exception Malformed_method_request of string
 exception Malformed_method_response of string
+exception Missing_field of string
 
 let get' name dict =
   if List.mem_assoc name dict then
@@ -551,81 +552,95 @@ let get' name dict =
 let get name dict =
   match get' name dict with
   | None ->
-    if Rpc.get_debug ()
-    then Printf.eprintf "%s was not found in the dictionary\n" name;
-    let str = List.map (fun (n,_) -> Printf.sprintf "%s=..." n) dict in
-    let str = Printf.sprintf "{%s}" (String.concat "," str) in
-    raise (Malformed_method_request str)
+    if Rpc.get_debug () then Printf.eprintf "%s was not found in the dictionary\n" name;
+    raise (Missing_field name)
   | Some v -> v
 
-let version_and_call_of_string str =
-  match of_string str with
-  | Dict d ->
-    let name =
-      match get "method" d with
-      | String s -> s
-      | _ -> raise (Malformed_method_request ("method " ^ str))
-    in
-    let version =
-      match get' "jsonrpc" d with
-      | None -> V1
-      | Some (String "2.0") -> V2
-      | _ -> raise (Malformed_method_request ("jsonrpc " ^ str))
-    in
-    let params =
-      match version with
-      | V1 ->
-        begin match get "params" d with
-        | Enum l -> l
-        | _ -> raise (Malformed_method_request ("params " ^ str))
-        end
-      | V2 ->
-        begin match get "params" d with
-          | Enum l -> l
-          | Dict l -> [Dict l]
-          | _ -> raise (Malformed_method_request ("params " ^ str))
-        end
-    in
-    let (_:int64) = match get "id" d with Int i -> i | _ -> raise (Malformed_method_request str) in
-    version, call name params
-  | _ -> raise (Malformed_method_request str)
+let version_id_and_call_of_string str =
+  try
+    match of_string str with
+    | Dict d ->
+      let name =
+        match get "method" d with
+        | String s -> s
+        | _ -> raise (Malformed_method_request "Invalid field 'method' in request body")
+      in
+      let version =
+        match get' "jsonrpc" d with
+        | None -> V1
+        | Some (String "2.0") -> V2
+        | _ -> raise (Malformed_method_request "Invalid field 'jsonrpc' in request body")
+      in
+      let params =
+        match version with
+        | V1 ->
+          begin match get "params" d with
+            | Enum l -> l
+            | _ -> raise (Malformed_method_request "Invalid field 'params' in request body")
+          end
+        | V2 ->
+          begin match get' "params" d with
+            | None -> []
+            | Some (Enum l) -> l
+            | Some (Dict l) -> [Dict l]
+            | _ -> raise (Malformed_method_request "Invalid field 'params' in request body")
+          end
+      in
+      let id =
+        match get "id" d with
+        | Int i as x -> x
+        | String s as y -> y
+        | _ -> raise (Malformed_method_request "Invalid field 'id' in request body")
+      in
+      version, id, call name params
+    | _ -> raise (Malformed_method_request "Invalid request body")
+  with Missing_field field ->
+    raise (Malformed_method_request (Printf.sprintf "Required field %s is missing" field))
 
 let call_of_string str =
-  snd ( version_and_call_of_string str)
+  let (_, _, call) = version_id_and_call_of_string str in
+  call
 
 let response_of_stream str =
-  match Parser.of_stream str with
-  | Dict d ->
-    let (_:int64) = match get "id" d with Int i -> i | _ -> raise (Malformed_method_response "id") in
-    begin match get' "jsonrpc" d with
-    | None ->
-      let result = get "result" d in
-      let error = get "error" d in
-      begin match result, error with
-        | v, Null    -> success v
-        | Null, v    -> failure v
-        | x,y        -> raise (Malformed_method_response (Printf.sprintf "<result=%s><error=%s>" (Rpc.to_string x) (Rpc.to_string y)))
-      end
-    | Some (String "2.0") ->
-      let result = get' "result" d in
-      let error = get' "error" d in
-      begin match result, error with
-        | Some v, None    -> success v
-        | None, Some v   -> begin
-            match v with
-            | Dict err ->
-              let (_:int64) = match get "code" err with Int i -> i | _ -> raise (Malformed_method_response "Error code") in
-              let _ = match get "message" err with String s -> s | _ -> raise (Malformed_method_response "Error message") in
-              failure v
-            | _ -> raise (Malformed_method_response "Error object")
+  try
+    match Parser.of_stream str with
+    | Dict d ->
+      let _ =
+        match get "id" d with
+        | Int i as x -> x
+        | String s as y -> y
+        | _ -> raise (Malformed_method_response "id") in
+      begin match get' "jsonrpc" d with
+        | None ->
+          let result = get "result" d in
+          let error = get "error" d in
+          begin match result, error with
+            | v, Null    -> success v
+            | Null, v    -> failure v
+            | x,y        -> raise (Malformed_method_response (Printf.sprintf "<result=%s><error=%s>" (Rpc.to_string x) (Rpc.to_string y)))
           end
-        | Some x, Some y  -> raise (Malformed_method_response (Printf.sprintf "<result=%s><error=%s>" (Rpc.to_string x) (Rpc.to_string y)))
-        | None, None      -> raise (Malformed_method_response (Printf.sprintf "neither <result> nor <error> was found"))
+        | Some (String "2.0") ->
+          let result = get' "result" d in
+          let error = get' "error" d in
+          begin match result, error with
+            | Some v, None    -> success v
+            | None, Some v   -> begin
+                match v with
+                | Dict err ->
+                  let (_:int64) = match get "code" err with Int i -> i | _ -> raise (Malformed_method_response "Error code") in
+                  let _ = match get "message" err with String s -> s | _ -> raise (Malformed_method_response "Error message") in
+                  failure v
+                | _ -> raise (Malformed_method_response "Error object")
+              end
+            | Some x, Some y  -> raise (Malformed_method_response (Printf.sprintf "<result=%s><error=%s>" (Rpc.to_string x) (Rpc.to_string y)))
+            | None, None      -> raise (Malformed_method_response (Printf.sprintf "neither <result> nor <error> was found"))
+          end
+        | _ ->
+          raise (Malformed_method_response "jsonrpc")
       end
-    | _ ->
-      raise (Malformed_method_response "jsonrpc")
-    end
-  | rpc -> raise (Malformed_method_response (Printf.sprintf "<response_of_stream(%s)>" (to_string rpc)))
+    | rpc -> raise (Malformed_method_response (Printf.sprintf "<response_of_stream(%s)>" (to_string rpc)))
+  with Missing_field field ->
+    raise (Malformed_method_response (Printf.sprintf "<%s was not found>" field))
 
 let response_of_string str =
   let i = ref (-1) in

--- a/lib/jsonrpc.mli
+++ b/lib/jsonrpc.mli
@@ -9,6 +9,7 @@ val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a
 val new_id : unit -> int64
 val string_of_call: ?version:version -> Rpc.call -> string
 val json_of_response : version -> Rpc.response -> Rpc.t
+val json_of_error_object : ?data:Rpc.t option -> int64 -> string -> Rpc.t
 val string_of_response: ?version:version -> Rpc.response -> string
 val a_of_response : ?version:version -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a
 type error =

--- a/lib/jsonrpc.mli
+++ b/lib/jsonrpc.mli
@@ -25,6 +25,7 @@ exception Malformed_method_request of string
 exception Malformed_method_response of string
 val get : string -> (string * 'a) list -> 'a
 val call_of_string : string -> Rpc.call
+val version_and_call_of_string : string -> version * Rpc.call
 val response_of_stream : (unit -> char) -> Rpc.response
 val response_of_string : string -> Rpc.response
 val response_of_in_channel : in_channel -> Rpc.response

--- a/lib/jsonrpc.mli
+++ b/lib/jsonrpc.mli
@@ -8,10 +8,10 @@ val to_string : Rpc.t -> string
 val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a
 val new_id : unit -> int64
 val string_of_call: ?version:version -> Rpc.call -> string
-val json_of_response : version -> Rpc.response -> Rpc.t
+val json_of_response : ?id:Rpc.t -> version -> Rpc.response -> Rpc.t
 val json_of_error_object : ?data:Rpc.t option -> int64 -> string -> Rpc.t
-val string_of_response: ?version:version -> Rpc.response -> string
-val a_of_response : ?version:version -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a
+val string_of_response: ?id:Rpc.t -> ?version:version -> Rpc.response -> string
+val a_of_response : ?id:Rpc.t -> ?version:version -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a
 type error =
     Unexpected_char of int * char * string
   | Invalid_value of int * string * string
@@ -26,7 +26,7 @@ exception Malformed_method_request of string
 exception Malformed_method_response of string
 val get : string -> (string * 'a) list -> 'a
 val call_of_string : string -> Rpc.call
-val version_and_call_of_string : string -> version * Rpc.call
+val version_id_and_call_of_string : string -> version * Rpc.t * Rpc.call
 val response_of_stream : (unit -> char) -> Rpc.response
 val response_of_string : string -> Rpc.response
 val response_of_in_channel : in_channel -> Rpc.response

--- a/tests/json.ml
+++ b/tests/json.ml
@@ -5,13 +5,122 @@ let good = "
  { \"a\":\"b\" }
 "
 
-let _ =
-  Printf.printf "Parsing good JSON ... %!";
-  let _ = Jsonrpc.of_string good in
+let v1 = "{
+  \"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"],
+	\"id\": 0
+}"
 
+let v1_null_id = "{
+  \"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"],
+	\"id\": null
+}"
+
+let v1_bad_id = "{
+	\"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"],
+	\"id\": \"0\"
+}"
+
+let v1_no_params ="{
+	\"method\": \"session.login_with_password\",
+	\"id\": \"0\"
+}"
+
+let v1_no_id = "{
+	\"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"]
+}"
+
+let v2 ="{
+	\"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"],
+	\"id\": 0,
+	\"jsonrpc\": \"2.0\"
+}"
+
+let v2_no_params = "{
+	\"method\": \"session.login_with_password\",
+	\"id\": 0,
+	\"jsonrpc\": \"2.0\"
+}"
+
+let v2_null_id = "{
+	\"method\": \"session.login_with_password\",
+  \"params\": [\"user\", \"password\"],
+  \"id\": null,
+	\"jsonrpc\": \"2.0\"
+}"
+
+let v2_no_method = "{
+	\"params\": [\"user\", \"password\"],
+	\"id\": 0,
+	\"jsonrpc\": \"2.0\"
+}"
+
+let v2_bad_id = "{
+	\"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"],
+	\"id\": \"0\",
+	\"jsonrpc\": \"2.0\"
+}"
+
+let v2_bad_jsonrpc = "{
+	\"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"],
+	\"id\": 0,
+	\"jsonrpc\": \"1.0\"
+}"
+
+let tests1 = [
+  "bad", bad, false;
+  "good", good, true;
+]
+
+let tests2 = [
+  "v1", v1, true;
+  "v1_null_id", v1_null_id, false; (*stricter than the specs*)
+  "v1_bad_id", v1_bad_id, false;
+  "v1_no_id", v1_no_id, false;
+  "v1_no_params", v1_no_params, false;
+  "v2", v2, true;
+  "v2_no_params", v2_no_params, false; (*stricter than the specs*)
+  "v2_null_id", v2_null_id, false; (*stricter than the specs*)
+  "v2_no_method", v2_no_method, false;
+  "v2_bad_id", v2_bad_id, false;
+  "v2_bad_jsonrpc", v2_bad_jsonrpc, false;
+]
+
+let handle_exception test_name e pass =
+  if pass then
+    (Printf.printf "Failed: test %s was not supposed to throw a parse failure\n" test_name;
+    false)
+  else
+    (Printf.printf "Passed: test %s threw %s\n" test_name (Printexc.to_string e);
+    true)
+
+
+let parse_json (test_name, json, pass) =
   try
-    Printf.printf "OK\nParsing bad JSON ... %!";
-    let _ = Jsonrpc.of_string bad in
-    failwith "The bad JSON should have generated a parse failure"
+    let _ = Jsonrpc.of_string json in
+    Printf.printf "Passed: test %s\n" test_name;
+    true;
   with e ->
-    Printf.printf "Caught %s:\nOK\n%!" (Printexc.to_string e)
+    handle_exception test_name e pass
+
+let call_of_json (test_name, json, pass) =
+  try
+    let _ = Jsonrpc.call_of_string json in
+    Printf.printf "Passed: test %s\n" test_name;
+    true
+  with e ->
+    handle_exception test_name e pass
+
+let _ =
+  let results1 = tests1 |> List.map parse_json in
+  let results2 = tests2 |> List.map call_of_json in
+  let failures = results1 @ results2 |> List.filter (fun x -> not x) in
+  match failures with
+  | [] -> ()
+  | _ -> failwith (Printf.sprintf "Test failures: %d"  (List.length failures))

--- a/tests/json.ml
+++ b/tests/json.ml
@@ -17,10 +17,16 @@ let v1_null_id = "{
 	\"id\": null
 }"
 
-let v1_bad_id = "{
+let v1_string_id = "{
 	\"method\": \"session.login_with_password\",
 	\"params\": [\"user\", \"password\"],
 	\"id\": \"0\"
+}"
+
+let v1_bad_id = "{
+	\"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"],
+	\"id\": [3]
 }"
 
 let v1_no_params ="{
@@ -59,11 +65,18 @@ let v2_no_method = "{
 	\"jsonrpc\": \"2.0\"
 }"
 
-let v2_bad_id = "{
+let v2_string_id = "{
 	\"method\": \"session.login_with_password\",
 	\"params\": [\"user\", \"password\"],
 	\"id\": \"0\",
 	\"jsonrpc\": \"2.0\"
+}"
+
+let v2_bad_id = "{
+	\"method\": \"session.login_with_password\",
+	\"params\": [\"user\", \"password\"],
+	\"id\": \"0\",
+	\"jsonrpc\": [2]
 }"
 
 let v2_bad_jsonrpc = "{
@@ -124,13 +137,15 @@ let tests1 = [
 let tests2 = [
   "v1", v1, true;
   "v1_null_id", v1_null_id, false; (*stricter than the specs*)
-  "v1_bad_id", v1_bad_id, false;
+  "v1_string_id", v1_string_id, true;
+  "v1_bad_id", v1_bad_id, false; (*stricter than the specs*)
   "v1_no_id", v1_no_id, false;
   "v1_no_params", v1_no_params, false;
   "v2", v2, true;
-  "v2_no_params", v2_no_params, false; (*stricter than the specs*)
+  "v2_no_params", v2_no_params, true;
   "v2_null_id", v2_null_id, false; (*stricter than the specs*)
   "v2_no_method", v2_no_method, false;
+  "v2_string_id", v2_string_id, true;
   "v2_bad_id", v2_bad_id, false;
   "v2_bad_jsonrpc", v2_bad_jsonrpc, false;
 ]


### PR DESCRIPTION
…ll from the request body.

Thus implementing clients can pass it to the other module functions requiring a
JSON-RPC version, in order to generate the right response.
Also, added some unit tests to cover various cases of request bodies.

Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>