### PR TITLE
Add defaults for polymorphic variants.

### DIFF
--- a/ppx_test/test.ml
+++ b/ppx_test/test.ml
@@ -221,6 +221,14 @@ let test_pvar_inherit2 () =
   check_marshal_unmarshal (`four "apple", Rpc.Enum [Rpc.String "four"; Rpc.String "apple"], rpc_of_test_pvar_inherit, test_pvar_inherit_of_rpc)
 
 type enum = [ `x | `y | `z | `default ] [@default `default] [@@deriving rpc]
+let test_default_enum () =
+  check_unmarshal_ok `default enum_of_rpc (Rpc.String "unknown_enum");
+  check_unmarshal_ok `default enum_of_rpc (Rpc.Enum [Rpc.String "thRee"; Rpc.Enum [ Rpc.Int 4L; Rpc.Int 5L]]);
+  check_unmarshal_error enum_of_rpc (Rpc.Enum [Rpc.Int 6L]);
+  check_unmarshal_error enum_of_rpc (Rpc.Dict ["foo",Rpc.String "bar"]);
+  check_unmarshal_error enum_of_rpc (Rpc.Int 1L);
+  check_unmarshal_error enum_of_rpc (Rpc.Float 1.0)
+
 type enum_string_map = (enum * string) list [@@deriving rpc]
 let test_enum_string_map () =
   check_marshal_unmarshal ([`x, "x"; `y, "y"; `z, "z"], Rpc.Dict ["x", Rpc.String "x"; "y", Rpc.String "y"; "z", Rpc.String "z"], rpc_of_enum_string_map, enum_string_map_of_rpc)
@@ -287,6 +295,7 @@ let suite =
     "polyvar_case" >:: test_polyvar_case;
     "pvar_inherit" >:: test_pvar_inherit;
     "pvar_inherit2" >:: test_pvar_inherit2;
+    "default_enum" >:: test_default_enum;
     "enum_string_map" >:: test_enum_string_map;
   ]
 

--- a/ppx_test/test.ml
+++ b/ppx_test/test.ml
@@ -220,6 +220,11 @@ let test_pvar_inherit () =
 let test_pvar_inherit2 () =
   check_marshal_unmarshal (`four "apple", Rpc.Enum [Rpc.String "four"; Rpc.String "apple"], rpc_of_test_pvar_inherit, test_pvar_inherit_of_rpc)
 
+type enum = [ `x | `y | `z | `default ] [@default `default] [@@deriving rpc]
+type enum_string_map = (enum * string) list [@@deriving rpc]
+let test_enum_string_map () =
+  check_marshal_unmarshal ([`x, "x"; `y, "y"; `z, "z"], Rpc.Dict ["x", Rpc.String "x"; "y", Rpc.String "y"; "z", Rpc.String "z"], rpc_of_enum_string_map, enum_string_map_of_rpc)
+
 
 let suite =
   "basic_tests" >:::
@@ -282,7 +287,7 @@ let suite =
     "polyvar_case" >:: test_polyvar_case;
     "pvar_inherit" >:: test_pvar_inherit;
     "pvar_inherit2" >:: test_pvar_inherit2;
-
+    "enum_string_map" >:: test_enum_string_map;
   ]
 
 let _ =


### PR DESCRIPTION
If the Rpc.t we're unmarshalling looks like it could be a valid
polymorphic variant (ie, it looks like a Rpc.String or an
Rpc.Enum [Rpc.String; ...]), then we return the default value.

This additionally fixes an issue when trying to marshal something
of type (<polyvar> * t) list. If the polyvar is representable as
an Rpc.String (ie, it has no extra values associated), then we
will now represent that as a Dict rather than as an Enum.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>