### PR TITLE
Remove deprecated stream functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     matrix:
         - OCAML_VERSION=4.02.3
         - OCAML_VERSION=4.03.0
-        - OCAML_VERSION=4.04.2
+        - OCAML_VERSION=4.04.2 REVDEPS=true
         - OCAML_VERSION=4.05.0
 matrix:
     fast_finish: true

--- a/example/Makefile
+++ b/example/Makefile
@@ -2,10 +2,10 @@ OCAMLC = ocamlfind ocamlc
 OCAMLOPT = ocamlfind ocamlopt
 OCAMLFLAGS = -annot -g -thread
 
-PACKS = lwt,lwt.unix,result,cmdliner,rresult,threads,xmlm
+PACKS = lwt,lwt.unix,result,cmdliner,rresult,threads,xmlm,yojson
 #,rpclib.cmdliner,rpclib.json,rpclib.html
 RPC = -I ../_build/lib
-RPCLINK = rpclib_core.cmxa rpclib.cmxa json.cmxa xml.cmxa cmdlinergen.cmxa markdowngen.cmxa
+RPCLINK = rpclib_core.cmxa rpclib.cmxa json.cmxa xml.cmxa cmdlinergen.cmxa markdowngen.cmxa yojson.cmxa
 
 PPXOPTS=-package ppx_deriving -ppxopt ppx_deriving,../_build/ppx/ppx_deriving_rpc.cma
 

--- a/example/example2_client.ml
+++ b/example/example2_client.ml
@@ -36,4 +36,9 @@ let server_cmd =
 
 let cli () =
   let rpc = binary_rpc Example2_idl.sockpath in
-  Cmdliner.Term.eval_choice default_cmd (server_cmd :: List.map (fun t -> t rpc) (Cmds.implementation ()))
+  Cmdliner.Term.eval_choice default_cmd (
+    server_cmd
+    :: List.map 
+      (fun t -> let (term, info) = t rpc in (Cmdliner.Term.(term $ const ()), info)) 
+      (Cmds.implementation ())
+    )

--- a/example/example3_client.ml
+++ b/example/example3_client.ml
@@ -93,6 +93,11 @@ let binary_rpc path (call: Rpc.call) : Rpc.response =
 
 let cli () =
   let rpc = binary_rpc "path" in
-  Cmdliner.Term.eval_choice default_cmd (generate_md_cmd :: (List.map (fun t -> t rpc) (PCmds.implementation () @ DCmds.implementation ())))
+  Cmdliner.Term.eval_choice default_cmd (
+    generate_md_cmd
+    :: (List.map 
+      (fun t -> let (term, info) = t rpc in (Cmdliner.Term.(term $ const ()), info)) 
+      (PCmds.implementation () @ DCmds.implementation ())
+    ))
 
 let _ = cli ()

--- a/lib/jsonrpc.ml
+++ b/lib/jsonrpc.ml
@@ -67,11 +67,6 @@ let to_string t =
   rpc_to_json t
   |> Y.to_string
 
-let to_a ~empty ~append t =
-  let buf = empty () in
-  to_fct t (fun s -> append buf s);
-  buf
-
 let new_id =
   let count = ref 0L in
   (fun () -> count := Int64.add 1L !count; !count)
@@ -138,25 +133,8 @@ let string_of_response ?(id=Int 0L) ?(version=V1) response =
   let json = json_of_response ~id version response in
   to_string json
 
-let a_of_response ?(id=Int 0L) ?(version=V1) ~empty ~append response =
-  let json = json_of_response ~id version response in
-  to_a ~empty ~append json
-
 
 let of_string s = s |> Y.from_string |> json_to_rpc
-let of_a ~next_char b =
-  let buf = Buffer.create 2048 in
-  let rec acc () =
-    try 
-      Buffer.add_char buf (next_char b);
-      acc ()
-    with _ -> ()
-  in
-  acc ();
-  Buffer.contents buf
-  |> of_string
-
-let of_fct f = of_a ~next_char:f ()
 
 let get' name dict = try Some (List.assoc name dict) with Not_found -> None
 
@@ -263,9 +241,6 @@ let get_response extractor str =
       raise (Malformed_method_response (Printf.sprintf "<%s was not found>" field))
     | JsonToRpcError json ->
       raise (Malformed_method_response (Printf.sprintf "<unable to parse %s>" (Y.to_string json)))
-
-let response_of_stream str =
-  get_response of_fct str
 
 let response_of_string str =
  get_response of_string str

--- a/lib/jsonrpc.ml
+++ b/lib/jsonrpc.ml
@@ -67,6 +67,11 @@ let to_string t =
   rpc_to_json t
   |> Y.to_string
 
+let to_a ~empty ~append t =
+  let buf = empty () in
+  to_fct t (fun s -> append buf s);
+  buf
+
 let new_id =
   let count = ref 0L in
   (fun () -> count := Int64.add 1L !count; !count)
@@ -132,6 +137,10 @@ let json_of_error_object ?(data=None) code message =
 let string_of_response ?(id=Int 0L) ?(version=V1) response =
   let json = json_of_response ~id version response in
   to_string json
+
+let a_of_response ?(id=Int 0L) ?(version=V1) ~empty ~append response =
+  let json = json_of_response ~id version response in
+  to_a ~empty ~append json
 
 
 let of_string s = s |> Y.from_string |> json_to_rpc

--- a/lib/jsonrpc.mli
+++ b/lib/jsonrpc.mli
@@ -11,6 +11,7 @@ val string_of_call: ?version:version -> Rpc.call -> string
 val string_of_response: ?id:Rpc.t -> ?version:version -> Rpc.response -> string
 
 val of_string : string -> Rpc.t
+val a_of_response : ?id:Rpc.t -> ?version:version -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a [@@ocaml.deprecated]
 val json_of_response : ?id:Rpc.t -> version -> Rpc.response -> Rpc.t
 val json_of_error_object : ?data:Rpc.t option -> int64 -> string -> Rpc.t
 

--- a/lib/jsonrpc.mli
+++ b/lib/jsonrpc.mli
@@ -1,23 +1,23 @@
 type version = V1 | V2
 
-val to_buffer : Rpc.t -> Buffer.t -> unit
-val to_string : Rpc.t -> string
-val to_fct : Rpc.t -> (string -> unit) -> unit [@@ocaml.deprecated]
-val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a [@@ocaml.deprecated]
-val new_id : unit -> int64
-val string_of_call: ?version:version -> Rpc.call -> string
-val json_of_response : ?id:Rpc.t -> version -> Rpc.response -> Rpc.t
-val json_of_error_object : ?data:Rpc.t option -> int64 -> string -> Rpc.t
-val string_of_response: ?id:Rpc.t -> ?version:version -> Rpc.response -> string
-val a_of_response : ?id:Rpc.t -> ?version:version -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a [@@ocaml.deprecated]
-val of_string : string -> Rpc.t
-val of_fct : (unit -> char) -> Rpc.t [@@ocaml.deprecated]
-val of_a : next_char:('a -> char) -> 'a -> Rpc.t [@@ocaml.deprecated]
 exception Malformed_method_request of string
 exception Malformed_method_response of string
+
+val new_id : unit -> int64
+
+val to_buffer : Rpc.t -> Buffer.t -> unit
+val to_string : Rpc.t -> string
+val string_of_call: ?version:version -> Rpc.call -> string
+val string_of_response: ?id:Rpc.t -> ?version:version -> Rpc.response -> string
+
+val of_string : string -> Rpc.t
+val json_of_response : ?id:Rpc.t -> version -> Rpc.response -> Rpc.t
+val json_of_error_object : ?data:Rpc.t option -> int64 -> string -> Rpc.t
+
 val get : string -> (string * 'a) list -> 'a
+
 val call_of_string : string -> Rpc.call
 val version_id_and_call_of_string : string -> version * Rpc.t * Rpc.call
-val response_of_stream : (unit -> char) -> Rpc.response [@@ocaml.deprecated]
+
 val response_of_string : string -> Rpc.response
 val response_of_in_channel : in_channel -> Rpc.response

--- a/lib/xmlrpc.mli
+++ b/lib/xmlrpc.mli
@@ -1,19 +1,18 @@
-val encode : string -> string
-val to_string : Rpc.t -> string
-val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a [@@ocaml.deprecated]
-val string_of_call : Rpc.call -> string
-val string_of_response : Rpc.response -> string
-val a_of_response :
-  empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a [@@ocaml.deprecated]
 exception Parse_error of string * string * Xmlm.input
 val pretty_string_of_error : string -> string -> Xmlm.input -> string
 val parse_error : string -> string -> Xmlm.input -> unit
+
+val encode : string -> string
+
+val to_string : Rpc.t -> string
+val string_of_call : Rpc.call -> string
+val string_of_response : Rpc.response -> string
+
 val of_string : ?callback:(string list -> Rpc.t -> unit) -> string -> Rpc.t
-val of_a :
-  ?callback:(string list -> Rpc.t -> unit) ->
-  next_char:('b -> char) -> 'b -> Rpc.t [@@ocaml.deprecated]
+
 val call_of_string :
   ?callback:(string list -> Rpc.t -> unit) -> string -> Rpc.call
+
 val response_of_fault :
   ?callback:(string list -> Rpc.t -> unit) -> Xmlm.input -> Rpc.response
 val response_of_success :

--- a/lib/xmlrpc.mli
+++ b/lib/xmlrpc.mli
@@ -1,18 +1,19 @@
+val encode : string -> string
+val to_string : Rpc.t -> string
+val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a [@@ocaml.deprecated]
+val string_of_call : Rpc.call -> string
+val string_of_response : Rpc.response -> string
+val a_of_response :
+  empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a [@@ocaml.deprecated]
 exception Parse_error of string * string * Xmlm.input
 val pretty_string_of_error : string -> string -> Xmlm.input -> string
 val parse_error : string -> string -> Xmlm.input -> unit
-
-val encode : string -> string
-
-val to_string : Rpc.t -> string
-val string_of_call : Rpc.call -> string
-val string_of_response : Rpc.response -> string
-
 val of_string : ?callback:(string list -> Rpc.t -> unit) -> string -> Rpc.t
-
+val of_a :
+  ?callback:(string list -> Rpc.t -> unit) ->
+  next_char:('b -> char) -> 'b -> Rpc.t [@@ocaml.deprecated]
 val call_of_string :
   ?callback:(string list -> Rpc.t -> unit) -> string -> Rpc.call
-
 val response_of_fault :
   ?callback:(string list -> Rpc.t -> unit) -> Xmlm.input -> Rpc.response
 val response_of_success :


### PR DESCRIPTION
And fix examples that broke after a change landed in `1.9.53` that changed the `cmdliner` generated interface