### PR TITLE
Abstract types

### DIFF
--- a/lib/rpc.ml
+++ b/lib/rpc.ml
@@ -63,6 +63,7 @@ module Types = struct
     | Tuple : 'a typ * 'b typ -> ('a * 'b) typ
     | Struct : 'a structure -> 'a typ
     | Variant : 'a variant -> 'a typ
+    | Abstract : 'a abstract -> 'a typ
 
   (* A type definition has a name and description *)
   and 'a def = { name: string; description: string list; ty: 'a typ; }
@@ -105,6 +106,10 @@ module Types = struct
     vdefault : 'a option;
     vversion : Version.t option;
     vconstructor : string -> tag_getter -> ('a, Rresult.R.msg) Result.result;
+  }
+  and 'a abstract = {
+    rpc_of : 'a -> t;
+    of_rpc : t -> ('a, Rresult.R.msg) Result.result;
   }
 
   let int    = { name="int";    ty=Basic Int;    description=["Native integer"]}

--- a/lib/rpc.mli
+++ b/lib/rpc.mli
@@ -57,6 +57,7 @@ module Types : sig
     | Tuple : 'a typ * 'b typ -> ('a * 'b) typ
     | Struct : 'a structure -> 'a typ
     | Variant : 'a variant -> 'a typ
+    | Abstract : 'a abstract -> 'a typ
   and 'a def = { name : string; description : string list; ty : 'a typ; }
   and boxed_def = BoxedDef : 'a def -> boxed_def
   and ('a, 's) field = {
@@ -95,6 +96,10 @@ module Types : sig
     vdefault : 'a option;
     vversion : Version.t option;
     vconstructor : string -> tag_getter -> ('a, Rresult.R.msg) Result.result;
+  }
+  and 'a abstract = {
+    rpc_of : 'a -> t;
+    of_rpc : t -> ('a, Rresult.R.msg) Result.result;
   }
   val int : int def
   val int32 : int32 def

--- a/lib/rpcmarshal.ml
+++ b/lib/rpcmarshal.ml
@@ -110,6 +110,8 @@ let rec unmarshal : type a. a typ -> Rpc.t -> (a, err) Result.result  = fun t v 
     >>= fun (name, contents) ->
     let constr = { tget = fun typ -> unmarshal typ contents } in
     vconstructor name constr
+  | Abstract { of_rpc } ->
+    of_rpc v
 
 
 let rec marshal : type a. a typ -> a -> Rpc.t = fun t v ->
@@ -173,6 +175,9 @@ let rec marshal : type a. a typ -> a -> Rpc.t = fun t v ->
               end
             | None -> acc) Rpc.Null variants
     end
+  | Abstract { rpc_of } -> begin
+      rpc_of v
+    end
 
 
 let ocaml_of_basic : type a. a basic -> string = function
@@ -203,3 +208,5 @@ let rec ocaml_of_t : type a. a typ -> string = function
         | BoxedTag t ->
           Printf.sprintf "| %s (%s) (** %s *)" t.tname (ocaml_of_t t.tcontents) (String.concat " " t.tdescription)) variants in
     String.concat " " tags
+  | Abstract _ ->
+    "<abstract>"


### PR DESCRIPTION
Allows the use of abstract types, so long as you've got an out-of-band way to marshal/unmarshal.