### PR TITLE
xmlrpc and jsonrpc: some cleanups

### DIFF
--- a/lib/cmdlinergen.ml
+++ b/lib/cmdlinergen.ml
@@ -107,6 +107,7 @@ module Gen () = struct
              | Rpc.String _ -> x
              | _ -> failwith "Type error"))
         (Cmdliner.Arg.(required & pos (incr ()) (some string) None & pinfo))
+    | Abstract _ -> failwith "Abstract types not supported by cmdlinergen"
 
   let declare name desc_list ty =
     let generate rpc =

--- a/lib/jsonrpc.ml
+++ b/lib/jsonrpc.ml
@@ -142,8 +142,18 @@ let a_of_response ?(id=Int 0L) ?(version=V1) ~empty ~append response =
   let json = json_of_response ~id version response in
   to_a ~empty ~append json
 
-
 let of_string s = s |> Y.from_string |> json_to_rpc
+
+let of_a ~next_char b =
+  let buf = Buffer.create 2048 in
+  let rec acc () =
+    match next_char b with
+    | Some c -> Buffer.add_char buf c; acc ()
+    | None -> ()
+  in
+  acc ();
+  Buffer.contents buf
+  |> of_string
 
 let get' name dict = try Some (List.assoc name dict) with Not_found -> None
 

--- a/lib/jsonrpc.mli
+++ b/lib/jsonrpc.mli
@@ -7,10 +7,12 @@ val new_id : unit -> int64
 
 val to_buffer : Rpc.t -> Buffer.t -> unit
 val to_string : Rpc.t -> string
+val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a [@@ocaml.deprecated]
 val string_of_call: ?version:version -> Rpc.call -> string
 val string_of_response: ?id:Rpc.t -> ?version:version -> Rpc.response -> string
 
 val of_string : string -> Rpc.t
+val of_a : next_char:('a -> char option) -> 'a -> Rpc.t [@@ocaml.deprecated]
 val a_of_response : ?id:Rpc.t -> ?version:version -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a [@@ocaml.deprecated]
 val json_of_response : ?id:Rpc.t -> version -> Rpc.response -> Rpc.t
 val json_of_error_object : ?data:Rpc.t option -> int64 -> string -> Rpc.t

--- a/lib/markdowngen.ml
+++ b/lib/markdowngen.ml
@@ -39,6 +39,7 @@ let rec string_of_t : type a.a typ -> string list =
   | Unit -> print "unit"
   | Option x -> string_of_t x @ (print " option")
   | Tuple (a, b) -> string_of_t a @ (print " * ") @ (string_of_t b)
+  | Abstract a -> print "abstract"
 
 let table headings rows =
   (* Slightly more convenient to have columns sometimes. This

--- a/lib/xmlrpc.ml
+++ b/lib/xmlrpc.ml
@@ -355,10 +355,10 @@ let of_string ?callback str =
 
 let of_a ?callback ~next_char b =
   let aux () =
-    try
-      let c = next_char b in
-      int_of_char c
-    with _ -> raise End_of_file in
+    match next_char b with
+    | Some c -> int_of_char c
+    | None   -> raise End_of_file
+  in
   let input = Xmlm.make_input (`Fun aux) in
   Parser.of_xml ?callback [] input
 

--- a/lib/xmlrpc.mli
+++ b/lib/xmlrpc.mli
@@ -11,7 +11,7 @@ val parse_error : string -> string -> Xmlm.input -> unit
 val of_string : ?callback:(string list -> Rpc.t -> unit) -> string -> Rpc.t
 val of_a :
   ?callback:(string list -> Rpc.t -> unit) ->
-  next_char:('b -> char) -> 'b -> Rpc.t [@@ocaml.deprecated]
+  next_char:('b -> char option) -> 'b -> Rpc.t [@@ocaml.deprecated]
 val call_of_string :
   ?callback:(string list -> Rpc.t -> unit) -> string -> Rpc.call
 val response_of_fault :


### PR DESCRIPTION
Having the `next_char` function return an optional char,
makes the interface more explicit instead of relying on
a badly documented exception mechanism.

With this interface we could consider un-deprecating the
functions.

I have re-added the corresponding functions for jsonrpc,
keeping them deprecated.

Also fixed some annoying warning for incomplete pattern
matches missing `Abstract _`. 
These are failures for cmdlinergen and simple "abstract" 
for markdowngen