### PR TITLE
Fix warnings and build, add support for ocaml-4.06

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ setup.data
 setup.log
 ppx_test/test
 ppx_test/tytest
+
+example/example.ml
+example/example
+example/example2
+example/example3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ env:
         - OCAML_VERSION=4.03.0
         - OCAML_VERSION=4.04.2 REVDEPS=true
         - OCAML_VERSION=4.05.0
+        - OCAML_VERSION=4.06.0
 matrix:
     fast_finish: true
     allow_failures:
-        - env: OCAML_VERSION=4.05.0
+        - env: OCAML_VERSION=4.06.0

--- a/_tags
+++ b/_tags
@@ -13,4 +13,5 @@
 <ppx/*>: cppo_n
 <lib/*>: cppo_V_OCAML
 <lib/*>: cppo_n
+<lib/rpc.*>: warn(-30)
 <true>: thread, safe_string

--- a/_tags
+++ b/_tags
@@ -11,4 +11,6 @@
 <ppx_test/*>: not_hygienic
 <ppx/*>: cppo_V_OCAML
 <ppx/*>: cppo_n
-<true>: thread
+<lib/*>: cppo_V_OCAML
+<lib/*>: cppo_n
+<true>: thread, safe_string

--- a/example/.merlin
+++ b/example/.merlin
@@ -1,6 +1,6 @@
-PKG ppx_deriving ppx_tools rpclib ppx_tools.metaquot result cow cmdliner ppx_deriving_rpc rresult
-S ppx
-S lib
-S tests
-S example
-B _build/lib
+PKG ppx_deriving ppx_tools rpclib ppx_tools.metaquot result cow cmdliner ppx_deriving_rpc rresult threads
+S ../ppx
+S ../lib
+S ../tests
+S ../example
+B ../_build/lib

--- a/example/Makefile
+++ b/example/Makefile
@@ -27,4 +27,4 @@ example3: example3_idl.ml example3_client.ml
 	$(OCAMLOPT) $(OCAMLFLAGS) $(PPXOPTS) -linkpkg -package $(PACKS) $(RPC) $(RPCLINK) -o example3 example3_idl.ml example3_client.ml
 
 clean:
-	rm -f example example2 example3 *.cmx *.cmi *.cmo *.o example.ml example.gen.ml *~ *.annot
+	rm -f example example2 example3 *.cmx *.cmi *.cmo *.o example.ml example.gen.ml *~ *.annot vm.md

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,6 +1,8 @@
 OCAMLC = ocamlfind ocamlc
 OCAMLOPT = ocamlfind ocamlopt
 OCAMLFLAGS = -annot -g -thread
+CPPO = cppo
+CPPOFLAGS = -n -V OCAML:4.04.2
 
 PACKS = lwt,lwt.unix,result,cmdliner,rresult,threads,xmlm,yojson
 #,rpclib.cmdliner,rpclib.json,rpclib.html
@@ -10,6 +12,9 @@ RPCLINK = rpclib_core.cmxa rpclib.cmxa json.cmxa xml.cmxa cmdlinergen.cmxa markd
 PPXOPTS=-package ppx_deriving -ppxopt ppx_deriving,../_build/ppx/ppx_deriving_rpc.cma
 
 default: example example2 example3
+
+example.ml:
+	$(CPPO) $(CPPOFLAGS) -o example.ml example.cppo.ml
 
 example: example.ml
 	$(OCAMLOPT) $(OCAMLFLAGS) $(PPXOPTS) -linkpkg -package $(PACKS) $(RPC) $(RPCLINK) -o example -dsource example.ml 2> example.gen.ml
@@ -22,4 +27,4 @@ example3: example3_idl.ml example3_client.ml
 	$(OCAMLOPT) $(OCAMLFLAGS) $(PPXOPTS) -linkpkg -package $(PACKS) $(RPC) $(RPCLINK) -o example3 example3_idl.ml example3_client.ml
 
 clean:
-	rm -f example example2 example3 *.cmx *.cmi *.cmo *.o example.gen.ml *~ *.annot
+	rm -f example example2 example3 *.cmx *.cmi *.cmo *.o example.ml example.gen.ml *~ *.annot

--- a/example/example.cppo.ml
+++ b/example/example.cppo.ml
@@ -1,3 +1,9 @@
+#if OCAML_VERSION < (4, 03, 0)
+    #define lowercase String.lowercase
+#else
+    #define lowercase String.lowercase_ascii
+#endif
+
 (* Example RPC *)
 
 (* The following is an example of how to use the ocaml-rpc library to define an
@@ -207,7 +213,7 @@ let exnt_variant : exnt variant = Rpc.Types.{
     vversion = None;
     vdefault = Some (Errors "unknown error tag!");
     vconstructor = (fun s t ->
-        match String.lowercase s with
+        match lowercase s with
         | "errors" -> Rresult.R.map errors.treview (t.tget (Basic String))
         | s -> Rresult.R.error_msg (Printf.sprintf "Unknown tag '%s'" s))
   }

--- a/example/example2_client.ml
+++ b/example/example2_client.ml
@@ -16,12 +16,12 @@ let binary_rpc path (call: Rpc.call) : Rpc.response =
   output_string oc len;
   output_string oc msg_buf;
   flush oc;
-  let len_buf = String.make 16 '\000' in
+  let len_buf = Bytes.make 16 '\000' in
   really_input ic len_buf 0 16;
-  let len = int_of_string len_buf in
-  let msg_buf = String.make len '\000' in
+  let len = int_of_string (Bytes.unsafe_to_string len_buf) in
+  let msg_buf = Bytes.make len '\000' in
   really_input ic msg_buf 0 len;
-  let (response: Rpc.response) = Jsonrpc.response_of_string msg_buf in
+  let (response: Rpc.response) = Jsonrpc.response_of_string (Bytes.unsafe_to_string msg_buf) in
   response
 
 let default_cmd =

--- a/example/example2_server.ml
+++ b/example/example2_server.ml
@@ -45,11 +45,11 @@ let binary_handler process s =
   let ic = Unix.in_channel_of_descr s in
   let oc = Unix.out_channel_of_descr s in
   (* Read a 16 byte length encoded as a string *)
-  let len_buf = String.make 16 '\000' in
-  really_input ic len_buf 0 (String.length len_buf);
-  let len = int_of_string len_buf in
-  let msg_buf = String.make len '\000' in
-  really_input ic msg_buf 0 (String.length msg_buf);
+  let len_buf = Bytes.make 16 '\000' in
+  really_input ic len_buf 0 (Bytes.length len_buf);
+  let len = int_of_string (Bytes.unsafe_to_string len_buf) in
+  let msg_buf = Bytes.make len '\000' in
+  really_input ic msg_buf 0 (Bytes.length msg_buf);
   let result = process msg_buf in
   let len_buf = Printf.sprintf "%016d" (String.length result) in
   output_string oc len_buf;
@@ -84,6 +84,6 @@ let start_server () =
   let rpc_fn = server Server.implementation in
 
   let process x =
-    Jsonrpc.string_of_response (rpc_fn (Jsonrpc.call_of_string x)) in
+    Jsonrpc.string_of_response (rpc_fn (Jsonrpc.call_of_string (Bytes.unsafe_to_string x))) in
 
   serve_requests process sockpath

--- a/example/example3_client.ml
+++ b/example/example3_client.ml
@@ -78,12 +78,12 @@ let binary_rpc path (call: Rpc.call) : Rpc.response =
   output_string oc len;
   output_string oc msg_buf;
   flush oc;
-  let len_buf = String.make 16 '\000' in
+  let len_buf = Bytes.make 16 '\000' in
   really_input ic len_buf 0 16;
-  let len = int_of_string len_buf in
-  let msg_buf = String.make len '\000' in
+  let len = int_of_string (Bytes.unsafe_to_string len_buf) in
+  let msg_buf = Bytes.make len '\000' in
   really_input ic msg_buf 0 len;
-  let (response: Rpc.response) = Jsonrpc.response_of_string msg_buf in
+  let (response: Rpc.response) = Jsonrpc.response_of_string (Bytes.unsafe_to_string msg_buf) in
   response
 
 (*let server_cmd =

--- a/lib/cmdlinergen.ml
+++ b/lib/cmdlinergen.ml
@@ -107,7 +107,14 @@ module Gen () = struct
              | Rpc.String _ -> x
              | _ -> failwith "Type error"))
         (Cmdliner.Arg.(required & pos (incr ()) (some string) None & pinfo))
-    | Abstract _ -> failwith "Abstract types not supported by cmdlinergen"
+    | Abstract {of_rpc; _} -> 
+      Term.app
+        (Term.pure (fun x -> 
+          let x = Jsonrpc.of_string x in
+          match of_rpc x with
+          | Ok _ -> x
+          | Error _ -> failwith "Type error"))
+        (Cmdliner.Arg.(required & pos (incr ()) (some string) None & pinfo))
 
   let declare name desc_list ty =
     let generate rpc =

--- a/lib/codegen.cppo.ml
+++ b/lib/codegen.cppo.ml
@@ -1,3 +1,9 @@
+#if OCAML_VERSION < (4, 03, 0)
+    #define capitalize String.capitalize
+#else
+    #define capitalize String.capitalize_ascii
+#endif
+
 open Rpc.Types
 
 type _ outerfn =
@@ -94,7 +100,7 @@ module Gen () = struct
 
   let implement i () =
     let n = i.Interface.name in
-    if String.capitalize n <> n then failwith "Interface names must be capitalized";
+    if capitalize n <> n then failwith "Interface names must be capitalized";
     let i = Interface.({details=i; methods=(List.rev !methods)}) in
     i
 

--- a/lib/htmlgen.ml
+++ b/lib/htmlgen.ml
@@ -28,6 +28,7 @@ let rec html_of_t : type a.a typ -> string list =
   | Unit -> print "unit"
   | Option x -> html_of_t x @ (print " option")
   | Tuple (a, b) -> html_of_t a @ (print " * ") @ (html_of_t b)
+  | Abstract _ -> print "<abstract>"
 
 (* Function inputs and outputs in a table *)
 let of_args args =

--- a/lib/markdowngen.ml
+++ b/lib/markdowngen.ml
@@ -39,7 +39,7 @@ let rec string_of_t : type a.a typ -> string list =
   | Unit -> print "unit"
   | Option x -> string_of_t x @ (print " option")
   | Tuple (a, b) -> string_of_t a @ (print " * ") @ (string_of_t b)
-  | Abstract a -> print "abstract"
+  | Abstract a -> print "<abstract>"
 
 let table headings rows =
   (* Slightly more convenient to have columns sometimes. This

--- a/lib/pythongen.ml
+++ b/lib/pythongen.ml
@@ -119,7 +119,8 @@ let rec typecheck : type a.a typ -> string -> t list = fun ty v ->
         typecheck a (Printf.sprintf "%s[0]" v) @
         typecheck b (Printf.sprintf "%s[1]" v))
     ]
-  | Abstract _ -> failwith "Abstract types not supported by pythongen"
+  | Abstract _ ->
+    failwith "Abstract types cannot be typechecked by pythongen"
 
 let rec value_of : type a. a typ -> string =
   let open Printf in function
@@ -150,7 +151,7 @@ let rec value_of : type a. a typ -> string =
       "None"
     | Tuple (a, b) ->
       "[]"
-    | Abstract _ -> failwith "Abstract types not supported by pythongen"
+    | Abstract _ -> failwith "Cannot get default value for abstract types"
 
 
 let exn_var myarg =

--- a/lib/pythongen.ml
+++ b/lib/pythongen.ml
@@ -119,6 +119,7 @@ let rec typecheck : type a.a typ -> string -> t list = fun ty v ->
         typecheck a (Printf.sprintf "%s[0]" v) @
         typecheck b (Printf.sprintf "%s[1]" v))
     ]
+  | Abstract _ -> failwith "Abstract types not supported by pythongen"
 
 let rec value_of : type a. a typ -> string =
   let open Printf in function
@@ -149,6 +150,7 @@ let rec value_of : type a. a typ -> string =
       "None"
     | Tuple (a, b) ->
       "[]"
+    | Abstract _ -> failwith "Abstract types not supported by pythongen"
 
 
 let exn_var myarg =

--- a/lib/rpc.cppo.ml
+++ b/lib/rpc.cppo.ml
@@ -15,10 +15,16 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 *)
 
+#if OCAML_VERSION < (4, 03, 0)
+    #define lowercase String.lowercase
+#else
+    #define lowercase String.lowercase_ascii
+#endif
+
+
 let debug = ref false
 let set_debug x = debug := x
 let get_debug () = !debug
-let lower = String.lowercase
 
 type t =
   | Int of int64
@@ -190,7 +196,7 @@ let char_of_rpc x =
   then failwith (Printf.sprintf "Char out of range (%d)" x)
   else Char.chr x
 let t_of_rpc t = t
-let lowerfn = function | String s -> String (lower s) | Enum (String s::ss) -> Enum ((String (lower s))::ss) | x -> x
+let lowerfn = function | String s -> String (lowercase s) | Enum (String s::ss) -> Enum ((String (lowercase s))::ss) | x -> x
 
 module ResultUnmarshallers = struct
   open Rresult

--- a/lib/rpc_genfake.ml
+++ b/lib/rpc_genfake.ml
@@ -100,4 +100,4 @@ let rec genall : type a. int -> string -> a typ -> a list  = fun depth strhint t
     List.map (function Rpc.Types.BoxedTag v ->
         let contents = genall (depth - 1) strhint v.tcontents in
         List.map (fun content -> v.treview content) contents) variants |> List.flatten |> thin depth
-        | Abstract _ -> failwith "Abstract types not supported by rpc_genfake"
+  | Abstract _ -> failwith "Abstract types not supported by rpc_genfake"

--- a/lib/rpc_genfake.ml
+++ b/lib/rpc_genfake.ml
@@ -46,6 +46,8 @@ let rec gentest : type a. a typ -> a list  = fun t ->
         let contents = gentest v.tcontents in
         let content = List.nth contents (Random.int (List.length contents)) in
         v.treview content) variants
+  | Abstract _ -> failwith "Abstract types not supported by rpc_genfake"
+
 
 let thin d result =
   if d < 0
@@ -98,3 +100,4 @@ let rec genall : type a. int -> string -> a typ -> a list  = fun depth strhint t
     List.map (function Rpc.Types.BoxedTag v ->
         let contents = genall (depth - 1) strhint v.tcontents in
         List.map (fun content -> v.treview content) contents) variants |> List.flatten |> thin depth
+        | Abstract _ -> failwith "Abstract types not supported by rpc_genfake"

--- a/lib/rpcmarshal.cppo.ml
+++ b/lib/rpcmarshal.cppo.ml
@@ -1,3 +1,9 @@
+#if OCAML_VERSION < (4, 03, 0)
+    #define lowercase String.lowercase
+#else
+    #define lowercase String.lowercase_ascii
+#endif
+
 (* Basic type definitions *)
 open Rpc.Types
 
@@ -85,10 +91,10 @@ let rec unmarshal : type a. a typ -> Rpc.t -> (a, err) Result.result  = fun t v 
   | Struct { constructor; sname } -> begin
       match v with
       | Rpc.Dict keys' ->
-        let keys = List.map (fun (s,v) -> (String.lowercase s, v)) keys' in
+        let keys = List.map (fun (s,v) -> (lowercase s, v)) keys' in
         constructor { fget = (
             let x : type a. string -> a typ -> (a, Rresult.R.msg) Result.result  = fun s ty ->
-              let s = String.lowercase s in
+              let s = lowercase s in
               match ty with
               | Option x -> begin try List.assoc s keys |> unmarshal x >>= fun o -> return (Some o) with _ -> return None end
               | y ->

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -4,6 +4,6 @@
 let () =
   Ocamlbuild_plugin.dispatch
     (fun hook ->
-      Ocamlbuild_cppo.dispatcher hook ;
+      Ocamlbuild_cppo.dispatcher hook;
       dispatch_default hook;
     )

--- a/opam
+++ b/opam
@@ -9,7 +9,6 @@ tags: [
   "org:xapi-project"
 ]
 build: [
-  [configure]
   [make]
 ]
 install: [

--- a/opam
+++ b/opam
@@ -25,7 +25,7 @@ build-test: [
 depends: [
   "oasis" {build}
   "cppo"  {build}
-  "async"
+  "async" {< "v0.10.0"}
   "cmdliner"
   "cow"
   "lwt"

--- a/ppx/ppx_deriving_rpc.cppo.ml
+++ b/ppx/ppx_deriving_rpc.cppo.ml
@@ -145,11 +145,17 @@ module Of_rpc = struct
         tags |> List.map (fun field ->
             match field with
             | Rtag (label, attrs, true, []) ->
+#if OCAML_VERSION > (4, 05, 0)
+              let label = label.txt in
+#endif
               let label' = lowercase label in
               Exp.case
                 [%pat? Rpc.String [%p pstr (attr_name label' attrs)]]
                 (Exp.variant label None)
             | Rtag (label, attrs, false, [ { ptyp_desc = Ptyp_tuple typs }]) ->
+#if OCAML_VERSION > (4, 05, 0)
+              let label = label.txt in
+#endif
               let label' = lowercase label in
               let exprs = List.mapi (fun i typ -> [%expr [%e expr_of_typ typ] [%e evar (argn i) ] ] ) typs in
               Exp.case
@@ -157,6 +163,9 @@ module Of_rpc = struct
                                  Rpc.Enum [%p plist (List.mapi (fun i _ -> pvar (argn i)) typs)]]]
                 (Exp.variant label (Some (tuple exprs)))
             | Rtag (label, attrs, false, [typ]) ->
+#if OCAML_VERSION > (4, 05, 0)
+              let label = label.txt in
+#endif
               let label' = lowercase label in
               Exp.case
                 [%pat? Rpc.Enum [Rpc.String [%p pstr (attr_name label' attrs)]; y]]
@@ -319,16 +328,25 @@ module Rpc_of = struct
         fields |> List.map (fun field ->
             match field with
             | Rtag (label, attrs, true, []) ->
+#if OCAML_VERSION > (4, 05, 0)
+              let label = label.txt in
+#endif
               Exp.case
                 (Pat.variant label None)
                 [%expr Rpc.String [%e str (attr_name label attrs)]]
             | Rtag (label, attrs, false, [{ ptyp_desc = Ptyp_tuple typs }]) ->
+#if OCAML_VERSION > (4, 05, 0)
+              let label = label.txt in
+#endif
               let l = list (List.mapi (fun i typ -> app (expr_of_typ  typ) [evar (argn i)]) typs) in
               Exp.case
                 (Pat.variant label (Some (ptuple (List.mapi (fun i _ -> pvar (argn i)) typs))))
                 [%expr Rpc.Enum ( Rpc.String ([%e str (attr_name label attrs)]) ::
                                   [Rpc.Enum [%e l]])]
             | Rtag (label, attrs, false, [typ]) ->
+#if OCAML_VERSION > (4, 05, 0)
+              let label = label.txt in
+#endif
               Exp.case
                 (Pat.variant label (Some [%pat? x]))
                 [%expr Rpc.Enum ( (Rpc.String ([%e str (attr_name label attrs)])) :: [ [%e expr_of_typ  typ] x])]


### PR DESCRIPTION
See https://github.com/mirage/ocaml-rpc/issues/67

`oasis setup` is run as a `make` step, and does already generate what is necessary for the build.

This should also fix https://github.com/mirage/ocaml-rpc/issues/69

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>