### PR TITLE
Add support for async and core >= v0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,13 @@ env:
         - DISTRO=debian-unstable
         - PACKAGE=rpc
     matrix:
-        - OCAML_VERSION=4.02.3
         - OCAML_VERSION=4.03.0
-        - OCAML_VERSION=4.04.2 REVDEPS=true
+        - OCAML_VERSION=4.04.2
         - OCAML_VERSION=4.05.0
         - OCAML_VERSION=4.06.0
+        - OCAML_VERSION=4.05.0 REVDEPS=true
 matrix:
     fast_finish: true
     allow_failures:
         - env: OCAML_VERSION=4.06.0
+        - env: OCAML_VERSION=4.05.0 REVDEPS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,14 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/ma
 script: bash -ex .travis-docker.sh
 env:
     global:
-        - DISTRO=debian-unstable
+        - DISTRO=debian-stable
         - PACKAGE=rpc
     matrix:
         - OCAML_VERSION=4.03.0
-        - OCAML_VERSION=4.04.2
+        - OCAML_VERSION=4.04.2 REVDEPS=true
         - OCAML_VERSION=4.05.0
         - OCAML_VERSION=4.06.0
-        - OCAML_VERSION=4.05.0 REVDEPS=true
 matrix:
     fast_finish: true
     allow_failures:
         - env: OCAML_VERSION=4.06.0
-        - env: OCAML_VERSION=4.05.0 REVDEPS=true

--- a/lib/rpc_async.ml
+++ b/lib/rpc_async.ml
@@ -1,5 +1,5 @@
 open Idl
-module Deferred = Async.Std.Deferred
+module Deferred = Async.Deferred
 
 type async_rpcfn = Rpc.call -> Rpc.response Deferred.t
 

--- a/opam
+++ b/opam
@@ -25,7 +25,7 @@ build-test: [
 depends: [
   "oasis" {build}
   "cppo"  {build}
-  "async" {< "v0.10.0"}
+  "async" {>= "v0.9.0" & < "v0.11.0"}
   "cmdliner"
   "cow"
   "lwt"
@@ -35,5 +35,7 @@ depends: [
   "type_conv" {>= "108.07.01"}
   "xmlm"
   "yojson"
+  "camlp4"
 ]
 depopts: [ "js_of_ocaml" ]
+available: [ ocaml-version >= "4.03.0" ]

--- a/tests/client_async_new.ml
+++ b/tests/client_async_new.ml
@@ -75,7 +75,7 @@ module ImplM = struct
 end
 
 let rpc rpc_fn call =
-  let open Async.Std.Deferred in
+  let open Async.Deferred in
   let call_string = Jsonrpc.string_of_call call in
   Printf.printf "rpc function: call_string='%s'\n" call_string;
   let call = Jsonrpc.call_of_string call_string in
@@ -120,4 +120,4 @@ let main () =
 
 let _ =
   ignore (main ());
-  Core.Std.never_returns (Async.Std.Scheduler.go ())
+  Core.never_returns (Async.Scheduler.go ())


### PR DESCRIPTION
Given that Core and Async are no longer supporting ocaml 4.02 since version v0.9.0, this PR requires dropping the compatibility with ocaml 4.02.3. So version 2.3.0 is the last one supporting ocaml 4.02.3.

Additional cleanups due to that will be part of the forthcoming port to jbuilder.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>