### PR TITLE
lib: remove use of codegen after dropping support for ocaml 4.02.3

### DIFF
--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -1,9 +1,3 @@
-#if OCAML_VERSION < (4, 03, 0)
-    #define capitalize String.capitalize
-#else
-    #define capitalize String.capitalize_ascii
-#endif
-
 open Rpc.Types
 
 type _ outerfn =
@@ -100,7 +94,7 @@ module Gen () = struct
 
   let implement i () =
     let n = i.Interface.name in
-    if capitalize n <> n then failwith "Interface names must be capitalized";
+    if String.capitalize_ascii n <> n then failwith "Interface names must be capitalized";
     let i = Interface.({details=i; methods=(List.rev !methods)}) in
     i
 

--- a/lib/rpc.ml
+++ b/lib/rpc.ml
@@ -15,13 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 *)
 
-#if OCAML_VERSION < (4, 03, 0)
-    #define lowercase String.lowercase
-#else
-    #define lowercase String.lowercase_ascii
-#endif
-
-
 let debug = ref false
 let set_debug x = debug := x
 let get_debug () = !debug
@@ -196,7 +189,7 @@ let char_of_rpc x =
   then failwith (Printf.sprintf "Char out of range (%d)" x)
   else Char.chr x
 let t_of_rpc t = t
-let lowerfn = function | String s -> String (lowercase s) | Enum (String s::ss) -> Enum ((String (lowercase s))::ss) | x -> x
+let lowerfn = function | String s -> String (String.lowercase_ascii s) | Enum (String s::ss) -> Enum ((String (String.lowercase_ascii s))::ss) | x -> x
 
 module ResultUnmarshallers = struct
   open Rresult

--- a/lib/rpcmarshal.ml
+++ b/lib/rpcmarshal.ml
@@ -1,9 +1,3 @@
-#if OCAML_VERSION < (4, 03, 0)
-    #define lowercase String.lowercase
-#else
-    #define lowercase String.lowercase_ascii
-#endif
-
 (* Basic type definitions *)
 open Rpc.Types
 
@@ -91,10 +85,10 @@ let rec unmarshal : type a. a typ -> Rpc.t -> (a, err) Result.result  = fun t v 
   | Struct { constructor; sname } -> begin
       match v with
       | Rpc.Dict keys' ->
-        let keys = List.map (fun (s,v) -> (lowercase s, v)) keys' in
+        let keys = List.map (fun (s,v) -> (String.lowercase_ascii s, v)) keys' in
         constructor { fget = (
             let x : type a. string -> a typ -> (a, Rresult.R.msg) Result.result  = fun s ty ->
-              let s = lowercase s in
+              let s = String.lowercase_ascii s in
               match ty with
               | Option x -> begin try List.assoc s keys |> unmarshal x >>= fun o -> return (Some o) with _ -> return None end
               | y ->


### PR DESCRIPTION
The rest of the cleanups will come after the next release, with the jbuilder port PR.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>