### PR TITLE
idl: add MakeInternalError functor that allows to forward unexpected internal errors

### DIFF
--- a/example/example3_idl.ml
+++ b/example/example3_idl.ml
@@ -29,9 +29,13 @@ type blocklist = {
 } [@@deriving rpcty]
 
 
-type error = Unimplemented of string [@@deriving rpcty]
+type error = Unimplemented of string | UnexpectedError of string [@@deriving rpcty]
 
-module E = Idl.Error.Make(struct type t=error let t = error end)
+module E = Idl.Error.Make(struct
+    type t = error
+    let t = error
+    let internal_error_of e = Some (UnexpectedError (Printexc.to_string e))
+    end)
 let error = E.error
 
 (** A string representing a Xen domain on the local host. The string is

--- a/lib/idl.ml
+++ b/lib/idl.ml
@@ -22,15 +22,33 @@ module Error = struct
     matcher : exn -> 'a option;
   }
 
-  module Make(T : sig type t val t : t Rpc.Types.def end) = struct
-    exception Exn of T.t
-    let error = {
-        def = T.t;
-        raiser = (function e -> Exn e);
-        matcher = (function | Exn e -> Some e | _ -> None)
-      }
+  module type ERROR = sig
+    type t
+    val t : t Rpc.Types.def
   end
 
+  module type INTERNAL_ERROR = sig 
+    include ERROR
+    val internal_error_of: exn -> t option
+  end
+
+  module Make(T : ERROR) = struct
+      exception Exn of T.t
+      let error = {
+          def = T.t;
+          raiser = (function e -> Exn e);
+          matcher = (function | Exn e -> Some e | _ -> None)
+        }
+    end
+
+  module MakeInternalError(T : INTERNAL_ERROR) = struct
+    include Make(T)
+
+    let error = {
+      error with
+        matcher = (function | Exn e -> Some e | e -> T.internal_error_of e)
+      }
+    end
 end
 
 module Interface = struct

--- a/lib/idl.ml
+++ b/lib/idl.ml
@@ -25,30 +25,17 @@ module Error = struct
   module type ERROR = sig
     type t
     val t : t Rpc.Types.def
-  end
-
-  module type INTERNAL_ERROR = sig 
-    include ERROR
     val internal_error_of: exn -> t option
   end
 
   module Make(T : ERROR) = struct
-      exception Exn of T.t
-      let error = {
-          def = T.t;
-          raiser = (function e -> Exn e);
-          matcher = (function | Exn e -> Some e | _ -> None)
-        }
-    end
-
-  module MakeInternalError(T : INTERNAL_ERROR) = struct
-    include Make(T)
-
+    exception Exn of T.t
     let error = {
-      error with
-        matcher = (function | Exn e -> Some e | e -> T.internal_error_of e)
-      }
-    end
+      def = T.t;
+      raiser = (function e -> Exn e);
+      matcher = (function | Exn e -> Some e | e -> T.internal_error_of e)
+    }
+  end
 end
 
 module Interface = struct

--- a/lib/idl.mli
+++ b/lib/idl.mli
@@ -34,15 +34,7 @@ module Error : sig
   module type ERROR = sig
     type t
     val t : t Rpc.Types.def
-  end
-
-  module type INTERNAL_ERROR = sig 
-    include ERROR
     val internal_error_of: exn -> t option
-  end
-
-  module MakeInternalError(T : INTERNAL_ERROR) : sig
-    val error : T.t t
   end
 
   module Make(T : ERROR) : sig

--- a/lib/idl.mli
+++ b/lib/idl.mli
@@ -31,7 +31,21 @@ module Error : sig
     matcher : exn -> 'a option;
   }
 
-  module Make(T : sig type t val t : t Rpc.Types.def end) : sig
+  module type ERROR = sig
+    type t
+    val t : t Rpc.Types.def
+  end
+
+  module type INTERNAL_ERROR = sig 
+    include ERROR
+    val internal_error_of: exn -> t option
+  end
+
+  module MakeInternalError(T : INTERNAL_ERROR) : sig
+    val error : T.t t
+  end
+
+  module Make(T : ERROR) : sig
     val error : T.t t
   end
 end


### PR DESCRIPTION
In many cases you want to pass these as well and deal with them separately.
But it is useful to keep the old `Make` for backward compatibility and for the cases you know you have complete reliability on the triggered errors.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>