### PR TITLE
 idl generation for lwt and async: fail if rpc server bindings are missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ env:
 matrix:
     fast_finish: true
     allow_failures:
-        - env: OCAML_VERSION=4.06.0
+        - env: OCAML_VERSION=4.04.2 REVDEPS=true

--- a/lib/rpc_lwt.ml
+++ b/lib/rpc_lwt.ml
@@ -40,35 +40,46 @@ module GenClient () = struct
     let rec inner : type b. (string * Rpc.t) list -> b fn -> b = fun cur ->
       function
       | Function (t, f) -> begin
-        let n = match t.Param.name with Some s -> s | None -> raise (MarshalError "Named parameters required for Lwt") in
-        fun v ->
-          match t.Param.typedef.Rpc.Types.ty, v with
-          | Rpc.Types.Option t1, None ->
-            inner cur f
-          | Rpc.Types.Option t1, Some v' ->
-            let marshalled = Rpcmarshal.marshal t1 v' in
-            inner ((n, marshalled) :: cur) f
-          | _, v ->
-            let marshalled = Rpcmarshal.marshal t.Param.typedef.Rpc.Types.ty v in
-            inner ((n, marshalled) :: cur) f
+          let n = match t.Param.name with Some s -> s | None -> raise (MarshalError "Named parameters required for Lwt") in
+          fun v ->
+            match t.Param.typedef.Rpc.Types.ty, v with
+            | Rpc.Types.Option t1, None ->
+              inner cur f
+            | Rpc.Types.Option t1, Some v' ->
+              let marshalled = Rpcmarshal.marshal t1 v' in
+              inner ((n, marshalled) :: cur) f
+            | _, v ->
+              let marshalled = Rpcmarshal.marshal t.Param.typedef.Rpc.Types.ty v in
+              inner ((n, marshalled) :: cur) f
         end
       | Returning (t, e) ->
         let call = Rpc.call name [(Rpc.Dict cur)] in
         let res = Lwt.bind (rpc call) (fun r ->
-          if r.Rpc.success
-          then match Rpcmarshal.unmarshal t.Param.typedef.Rpc.Types.ty r.Rpc.contents with Ok x -> Lwt.return (Ok x) | Error (`Msg x) -> Lwt.fail (MarshalError x)
-          else match Rpcmarshal.unmarshal e.Idl.Error.def.Rpc.Types.ty r.Rpc.contents with Ok x -> Lwt.return (Error x) | Error (`Msg x) -> Lwt.fail (MarshalError x)) in
+            if r.Rpc.success
+            then match Rpcmarshal.unmarshal t.Param.typedef.Rpc.Types.ty r.Rpc.contents with Ok x -> Lwt.return (Ok x) | Error (`Msg x) -> Lwt.fail (MarshalError x)
+            else match Rpcmarshal.unmarshal e.Idl.Error.def.Rpc.Types.ty r.Rpc.contents with Ok x -> Lwt.return (Error x) | Error (`Msg x) -> Lwt.fail (MarshalError x)) in
         {M.lwt=res}
     in inner [] ty
 end
 
 exception MarshalError of string
 exception UnknownMethod of string
+exception UnboundImplementation of string list
 
-type server_implementation = (string, lwt_rpcfn) Hashtbl.t
-let server hashtbl call =
-  let fn = try Hashtbl.find hashtbl call.Rpc.name with Not_found -> raise (UnknownMethod call.Rpc.name) in
-  fn call
+type server_implementation = (string, lwt_rpcfn option) Hashtbl.t
+
+let server hashtbl =
+  let impl = Hashtbl.create (Hashtbl.length hashtbl) in
+  let unbound_impls = Hashtbl.fold (fun key fn acc ->
+      match fn with
+      | None -> key::acc
+      | Some fn -> Hashtbl.add impl key fn; acc
+    ) hashtbl [] in
+  if unbound_impls <> [] then
+    raise (UnboundImplementation unbound_impls);
+  fun call ->
+    let fn = try Hashtbl.find impl call.Rpc.name with Not_found -> raise (UnknownMethod call.Rpc.name) in
+    fn call
 
 let combine hashtbls =
   let result = Hashtbl.create 16 in
@@ -87,7 +98,7 @@ module GenServer () = struct
 
   type ('a,'b) comp = ('a,'b) Result.result M.lwt
   type rpcfn = Rpc.call -> Rpc.response Lwt.t
-  type funcs = (string, rpcfn) Hashtbl.t
+  type funcs = (string, rpcfn option) Hashtbl.t
   type 'a res = 'a -> unit
 
   type _ fn =
@@ -99,7 +110,7 @@ module GenServer () = struct
 
   let empty : unit -> funcs = fun () -> Hashtbl.create 20
 
-  let declare : string -> string list -> 'a fn -> 'a res = fun name _ ty impl ->
+  let declare : string -> string list -> 'a fn -> 'a res = fun name _ ty ->
     let open Rresult.R in
     let get_named_args call =
       match call.params with
@@ -120,26 +131,29 @@ module GenServer () = struct
       end
     in
 
-    let rpcfn =
-      let rec inner : type a. a fn -> a -> call -> response Lwt.t = fun f impl call ->
-        Lwt.bind (get_named_args call) (fun args ->
-        match f with
-        | Function (t, f) -> begin
-            let n = match t.Param.name with | Some s -> s | None -> raise (MarshalError "Named parameters required for Lwt") in
-            let is_opt = match t.Param.typedef.Rpc.Types.ty with | Rpc.Types.Option _ -> true | _ -> false in
-            Lwt.bind (get_arg args n is_opt) (fun arg_rpc ->
-            let z = Rpcmarshal.unmarshal t.Param.typedef.Rpc.Types.ty arg_rpc in
-            match z with
-            | Result.Ok arg -> inner f (impl arg) call
-            | Result.Error (`Msg m) -> Lwt.fail (MarshalError m))
-          end
-        | Returning (t,e) -> begin
-            Lwt.bind impl.M.lwt (function
-                  | Result.Ok x -> Lwt.return (success (Rpcmarshal.marshal t.Param.typedef.Rpc.Types.ty x))
-                  | Result.Error y -> Lwt.return (failure (Rpcmarshal.marshal e.Idl.Error.def.Rpc.Types.ty y)))
-          end)
-      in inner ty impl
-    in
+    Hashtbl.add funcs name None;
+    fun impl ->
+      let rpcfn =
+        let rec inner : type a. a fn -> a -> call -> response Lwt.t = fun f impl call ->
+          Lwt.bind (get_named_args call) (fun args ->
+              match f with
+              | Function (t, f) -> begin
+                  let n = match t.Param.name with | Some s -> s | None -> raise (MarshalError "Named parameters required for Lwt") in
+                  let is_opt = match t.Param.typedef.Rpc.Types.ty with | Rpc.Types.Option _ -> true | _ -> false in
+                  Lwt.bind (get_arg args n is_opt) (fun arg_rpc ->
+                      let z = Rpcmarshal.unmarshal t.Param.typedef.Rpc.Types.ty arg_rpc in
+                      match z with
+                      | Result.Ok arg -> inner f (impl arg) call
+                      | Result.Error (`Msg m) -> Lwt.fail (MarshalError m))
+                end
+              | Returning (t,e) -> begin
+                  Lwt.bind impl.M.lwt (function
+                      | Result.Ok x -> Lwt.return (success (Rpcmarshal.marshal t.Param.typedef.Rpc.Types.ty x))
+                      | Result.Error y -> Lwt.return (failure (Rpcmarshal.marshal e.Idl.Error.def.Rpc.Types.ty y)))
+                end)
+        in inner ty impl
+      in
 
-    Hashtbl.add funcs name rpcfn
+      Hashtbl.replace funcs name (Some rpcfn)
+
 end

--- a/lib/rpc_lwt.mli
+++ b/lib/rpc_lwt.mli
@@ -30,8 +30,9 @@ module GenClient () :
 
 exception MarshalError of string
 exception UnknownMethod of string
+exception UnboundImplementation of string list
 
-type server_implementation = (string, lwt_rpcfn) Hashtbl.t
+type server_implementation
 val server : server_implementation -> lwt_rpcfn
 val combine : server_implementation list -> server_implementation
 
@@ -41,7 +42,7 @@ module GenServer () :
     val implement : Idl.Interface.description -> implementation
     type ('a,'b) comp = ('a,'b) Result.result M.lwt
     type rpcfn = Rpc.call -> Rpc.response Lwt.t
-    type funcs = (string, rpcfn) Hashtbl.t
+    type funcs = (string, rpcfn option) Hashtbl.t
     type 'a res = 'a -> unit
     type _ fn =
         Function : 'a Idl.Param.t * 'b fn -> ('a -> 'b) fn


### PR DESCRIPTION
This completes https://github.com/mirage/ocaml-rpc/pull/82