### PR TITLE
Fix marshalling of optional arguments

### DIFF
--- a/lib/rpc_async.ml
+++ b/lib/rpc_async.ml
@@ -40,7 +40,7 @@ module GenClient () = struct
     let rec inner : type b. (string * Rpc.t) list -> b fn -> b = fun cur ->
       function
       | Function (t, f) -> begin
-        let n = match t.Param.name with Some s -> s | None -> raise (MarshalError "Named parameters required for Lwt") in
+        let n = match t.Param.name with Some s -> s | None -> raise (MarshalError "Named parameters required for Async") in
         fun v ->
           match t.Param.typedef.Rpc.Types.ty, v with
           | Rpc.Types.Option t1, None ->

--- a/lib/rpc_lwt.ml
+++ b/lib/rpc_lwt.ml
@@ -111,12 +111,12 @@ module GenServer () = struct
       if is_opt
       then begin
         if List.mem_assoc name args
-        then Rpc.Enum [List.assoc name args]
-        else Rpc.Enum []
+        then Lwt.return (Rpc.Enum [List.assoc name args])
+        else Lwt.return (Rpc.Enum [])
       end else begin
         if List.mem_assoc name args
-        then List.assoc name args
-        else raise (MarshalError (Printf.sprintf "Argument missing: %s" name))
+        then Lwt.return (List.assoc name args)
+        else Lwt.fail (MarshalError (Printf.sprintf "Argument missing: %s" name))
       end
     in
 


### PR DESCRIPTION
Previously if an argument to an RPC call was a named optional value it
would be unconditionally added to the dictionary of params and the
optionness encoded by either passing an empty or one element Enum in
the dict. This patch makes it more consistent with how optional
record values are encoded - if 'None' the names argument is now
omitted from the arg dict, and if 'Some' the value is unboxed from the
Enum and put directly into the dict.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>