### PR TITLE
pythongen: allow optional fields of structs to be absent

### DIFF
--- a/lib/pythongen.ml
+++ b/lib/pythongen.ml
@@ -58,7 +58,14 @@ let rec typecheck : type a.a typ -> string -> t list = fun ty v ->
   | Struct { fields } ->
     let check boxedfield =
       let BoxedField f = boxedfield in
-      typecheck f.field (sprintf "%s['%s']" v f.fname) in
+      let member = (sprintf "%s['%s']" v f.fname) in
+      match f.field with
+      | Option ty ->
+        [ Line (sprintf "if '%s' in %s:" f.fname v)
+        ; Block (typecheck ty member)
+        ]
+      | _ -> typecheck f.field member
+    in
     List.concat (List.rev (List.map check (List.rev fields)))
   | Variant { variants } ->
     let check first boxed_tag =


### PR DESCRIPTION
Previously the generated python code failed in the typechecking Python
code when an optional field wasn't present in the Python dictionary. Now
we only typecheck the optional field if it is actually there in the
dict.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>