### PR TITLE
markdowngen: escape special HTML and markdown chars

### DIFF
--- a/src/lib/internals.ml
+++ b/src/lib/internals.ml
@@ -1,0 +1,29 @@
+
+(** Encodes a string using the given translation function that maps a character
+    to a string that is its encoded version, if that character needs encoding. *)
+let encode translate s =
+  let n = String.length s in
+  let need_encoding =
+    let b = ref false in
+    let i = ref 0 in
+    while not !b && !i < n do
+      b := translate s.[ !i ] <> None;
+      incr i;
+    done;
+    !b in
+  if need_encoding then begin
+    let buf = Buffer.create 0 in
+    let m = ref 0 in
+    for i = 0 to n-1 do
+      match translate s.[i] with
+      | None   -> ()
+      | Some n ->
+        Buffer.add_substring buf s !m (i - !m);
+        Buffer.add_string buf n;
+        m := i + 1
+    done;
+    Buffer.add_substring buf s !m (n - !m);
+    Buffer.contents buf
+  end else
+    s
+

--- a/src/lib/jbuild
+++ b/src/lib/jbuild
@@ -1,4 +1,11 @@
 (library
+ ((name internals)
+  (public_name rpclib.internals)
+  (modules (internals))
+  (wrapped false)
+ ))
+
+(library
  ((name rpclib_core)
   (public_name rpclib.core)
   (modules (rpc idl rpcmarshal pythongen codegen rpc_genfake))
@@ -11,7 +18,8 @@
  ((name xml)
   (public_name rpclib.xml)
   (modules (xmlrpc))
-  (libraries (rpclib.core 
+  (libraries (internals
+              rpclib.core
               xmlm))
   (wrapped false)
  ))

--- a/src/lib/xmlrpc.ml
+++ b/src/lib/xmlrpc.ml
@@ -25,9 +25,8 @@ let debug (fmt: ('a, unit, string, unit) format4) : 'a =
 (* marshalling/unmarshalling code *)
 
 (* The XML-RPC is not very clear about what characters can be in a string value ... *)
-let encode s =
-  let n = String.length s in
-  let aux = function
+let encode =
+  let translate = function
     | '>'    -> Some "&gt;"
     | '<'    -> Some "&lt;"
     | '&'    -> Some "&amp;"
@@ -35,29 +34,7 @@ let encode s =
     | c when (c >= '\x20' && c <= '\xff') || c = '\x09' || c = '\x0a' || c = '\x0d'
       -> None
     | _      -> Some "" in
-  let need_encoding =
-    let b = ref false in
-    let i = ref 0 in
-    while not !b && !i < n do
-      b := aux s.[ !i ] <> None;
-      incr i;
-    done;
-    !b in
-  if need_encoding then begin
-    let buf = Buffer.create 0 in
-    let m = ref 0 in
-    for i = 0 to n-1 do
-      match aux s.[i] with
-      | None   -> ()
-      | Some n ->
-        Buffer.add_substring buf s !m (i - !m);
-        Buffer.add_string buf n;
-        m := i + 1
-    done;
-    Buffer.add_substring buf s !m (n - !m);
-    Buffer.contents buf
-  end else
-    s
+  Internals.encode translate
 
 let rec add_value f = function
   | Null ->


### PR DESCRIPTION
To reuse the encode function from xmlrpc.ml, I've added a new
"internals" library & module that can be used to share helpers between
the various libraries and modules.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>