### PR TITLE
rpcty ppx: Avoid warning 23: "with clause is useless"

### DIFF
--- a/ppx/ppx_deriving_rpcty.cppo.ml
+++ b/ppx/ppx_deriving_rpcty.cppo.ml
@@ -124,12 +124,13 @@ module Typ_of = struct
         [ Vb.mk (pvar typ_of_lid) (polymorphize (expr_of_typ manifest))]
       | Ptype_record labels, _ ->
         let fields =
+          let one_field = match labels with [_] -> true | _ -> false in
           labels |> List.map (fun { pld_name = { txt = fname }; pld_type; pld_attributes } ->
               let rpc_name = attr_key fname pld_attributes in
               let default = attr_default pld_attributes in
               let field_name = String.concat "_" [name; fname] in
               let fget = [%expr fun _r -> [%e Exp.field (evar "_r") (mknoloc (Lident fname)) ] ] in
-              let fset = [%expr fun v s -> [%e record [fname, [%expr v]] ~over:([%expr s])]] in
+              let fset = [%expr fun v s -> [%e record [fname, [%expr v]] ?over:(if one_field then None else Some ([%expr s]))]] in
               (fname,
                rpc_name,
                field_name,

--- a/tests/ppx/jbuild
+++ b/tests/ppx/jbuild
@@ -1,5 +1,6 @@
 (executable
  ((name suite)
+  (flags (:standard -warn-error +a))
   (libraries (
      alcotest
      ppx_deriving

--- a/tests/ppx/test_deriving_rpcty.ml
+++ b/tests/ppx/test_deriving_rpcty.ml
@@ -117,11 +117,12 @@ let test_variant_name2 () =
 type test_record = {
   fiEld1 : int;
   fiEld2 : string;
+  fiEld3 : bool;
 } [@@deriving rpcty]
 let test_record () =
-  check_marshal_unmarshal ({fiEld1=7; fiEld2="banana"}, Rpc.Dict ["fiEld1",Rpc.Int 7L; "fiEld2",Rpc.String "banana"], typ_of_test_record)
+  check_marshal_unmarshal ({fiEld1=7; fiEld2="banana"; fiEld3=false}, Rpc.Dict ["fiEld1",Rpc.Int 7L; "fiEld2",Rpc.String "banana"; "fiEld3",Rpc.Bool false], typ_of_test_record)
 let test_record_case () =
-  check_unmarshal_ok {fiEld1=7; fiEld2="banana"} typ_of_test_record (Rpc.Dict ["field1",Rpc.Int 7L; "FIELD2",Rpc.String "banana"])
+  check_unmarshal_ok {fiEld1=7; fiEld2="banana"; fiEld3=false} typ_of_test_record (Rpc.Dict ["field1",Rpc.Int 7L; "FIELD2",Rpc.String "banana"; "Field3",Rpc.Bool false])
 let test_bad_record () =
   check_unmarshal_error typ_of_test_record (Rpc.Dict ["field1",Rpc.Int 7L;])
 
@@ -143,6 +144,12 @@ type test_record_attrs = {
 } [@@deriving rpcty]
 let test_record_attrs () =
   check_marshal_unmarshal ({field5=6}, Rpc.Dict ["foo", Rpc.Int 6L], typ_of_test_record_attrs)
+
+type test_record_one_field = {
+  field : bool
+} [@@deriving rpcty]
+let test_record_one_field () =
+  check_marshal_unmarshal ({field=true}, Rpc.Dict ["field", Rpc.Bool true], typ_of_test_record_one_field)
 
 type key = string [@@deriving rpcty]
 type test_dict_key = (key * int) list [@@deriving rpcty]
@@ -245,6 +252,7 @@ let tests =
   ; "record_opt3", `Quick, test_record_opt3
   ; "record_opt4", `Quick, test_record_opt4
   ; "record_attrs", `Quick, test_record_attrs
+  ; "record_one_field", `Quick, test_record_one_field
   ; "poly", `Quick, test_poly
   ; "fakegen", `Quick, fakegen
   ; "defaults", `Quick, test_defaults


### PR DESCRIPTION
When setting the record field of a record that has only one field, avoid
this warning, by omitting the "with" clause:

Warning 23: all the fields are explicitly listed in this record:
the 'with' clause is useless.

I've updated the flags of the PPX test suite so that now it would fail
if any warning appeared. This change is useful for projects that have
enabled all warnings as errors.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>