### PR TITLE
rpcty ppx: Fix warning 27 in generated field setter

### DIFF
--- a/ppx/ppx_deriving_rpcty.cppo.ml
+++ b/ppx/ppx_deriving_rpcty.cppo.ml
@@ -130,7 +130,7 @@ module Typ_of = struct
               let default = attr_default pld_attributes in
               let field_name = String.concat "_" [name; fname] in
               let fget = [%expr fun _r -> [%e Exp.field (evar "_r") (mknoloc (Lident fname)) ] ] in
-              let fset = [%expr fun v s -> [%e record [fname, [%expr v]] ?over:(if one_field then None else Some ([%expr s]))]] in
+              let fset = [%expr fun v _s -> [%e record [fname, [%expr v]] ?over:(if one_field then None else Some ([%expr _s]))]] in
               (fname,
                rpc_name,
                field_name,

--- a/tests/ppx/test_deriving_rpcty.ml
+++ b/tests/ppx/test_deriving_rpcty.ml
@@ -145,9 +145,11 @@ type test_record_attrs = {
 let test_record_attrs () =
   check_marshal_unmarshal ({field5=6}, Rpc.Dict ["foo", Rpc.Int 6L], typ_of_test_record_attrs)
 
+[@@@warning "+27"]
 type test_record_one_field = {
   field : bool
 } [@@deriving rpcty]
+[@@@warning "-27"]
 let test_record_one_field () =
   check_marshal_unmarshal ({field=true}, Rpc.Dict ["field", Rpc.Bool true], typ_of_test_record_one_field)
 


### PR DESCRIPTION
While fixing warning 23, I've introduced warning 27, the "s" record
parameter was unused in case of records with only one field.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>