### PR TITLE
pythongen test: make pylint checks stricter

### DIFF
--- a/tests/rpc/test_pythongen.ml
+++ b/tests/rpc/test_pythongen.ml
@@ -60,7 +60,7 @@ let run_linters file =
     print_endline cmd;
     Alcotest.(check int) msg 0 (Sys.command cmd)
   in
-  run "pylint should exit with 0" ("pylint --errors-only " ^ file);
+  run "pylint should exit with 0" ("pylint --disable=line-too-long,too-few-public-methods,unused-argument,no-self-use,invalid-name,broad-except,protected-access,redefined-builtin " ^ file);
   run "pycodestyle should exit with 0" ("pycodestyle --ignore=E501 " ^ file)
 
 let lint_bindings () =


### PR DESCRIPTION
Instead of only checking for errors, now we have a whitelist of
warnings.

I had to rename TypeError to RpcTypeError to ensure it does not class
with the built-in exception with the same name. It does not seem to be
used by clients, SM raises the normal TypeError at a few places, but
that should be fine.

Warnings I did not remove:
* line-too-long,too-few-public-methods(for the exns),unused-argument(for
  the skeleton classes),no-self-use(for the skeletons, ...):
  it's pointless or impossible to remove these
* invalid-name: We cannot convert the classes to CamelCase without breaking the interface
* broad-except: it is necessary to catch all exceptions at some places
* protected-access: I did not want to make _dispatcher public for now

Fixes #111 

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>