### PR TITLE
add option in jsonrpc.of_string to ignore tailing junk from input

### DIFF
--- a/src/lib/jsonrpc.mli
+++ b/src/lib/jsonrpc.mli
@@ -11,7 +11,8 @@ val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a [@
 val string_of_call: ?version:version -> Rpc.call -> string
 val string_of_response: ?id:Rpc.t -> ?version:version -> Rpc.response -> string
 
-val of_string : string -> Rpc.t
+val of_string : ?strict:bool -> string -> Rpc.t
+
 val of_a : next_char:('a -> char option) -> 'a -> Rpc.t [@@ocaml.deprecated]
 val a_of_response : ?id:Rpc.t -> ?version:version -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a [@@ocaml.deprecated]
 val json_of_response : ?id:Rpc.t -> version -> Rpc.response -> Rpc.t
@@ -22,5 +23,5 @@ val get : string -> (string * 'a) list -> 'a
 val call_of_string : string -> Rpc.call
 val version_id_and_call_of_string : string -> version * Rpc.t * Rpc.call
 
-val response_of_string : string -> Rpc.response
+val response_of_string : ?strict:bool -> string -> Rpc.response
 val response_of_in_channel : in_channel -> Rpc.response

--- a/tests/lib/json.ml
+++ b/tests/lib/json.ml
@@ -5,6 +5,10 @@ let valid_json = "
  { \"a\":\"b\" }
 "
 
+let valid_json_with_junk = "
+ { \"a\":\"b\" }Some junk
+"
+
 let v1 = "{
   \"method\": \"session.login_with_password\",
 	\"params\": [\"user\", \"password\"],
@@ -99,6 +103,12 @@ let v2_success = "{
     \"id\": 0
 }"
 
+let v2_success_with_junk = "{
+    \"jsonrpc\": \"2.0\",
+    \"result\": \"OpaqueRef:0d01bcdd-9b33-a0d8-1870-d4fb80af354e\",
+    \"id\": 0
+}{!&some junk for test"
+
 let v2_failure_bad_error = "{
     \"jsonrpc\": \"2.0\",
     \"error\": [ \"SESSION_AUTHENTICATION_FAILED\", \"root\", \"Authentication failure\" ],
@@ -132,6 +142,11 @@ let v2_failure_bad_message = "{
 let tests_json = [
   "invalid_json", invalid_json, false;
   "valid_json", valid_json, true;
+  "valid_json_with_junk", valid_json_with_junk, false;
+]
+
+let tests_json_plus = [
+  "valid_json_with_junk", valid_json_with_junk, true;
 ]
 
 let tests_call = [
@@ -152,12 +167,17 @@ let tests_call = [
 
 let tests_response = [
   "v2_success", v2_success, true;
+  "v2_success_with_junk", v2_success_with_junk, false;
   "v2_failure", v2_failure, false;
   "v2_mixed", v2_mixed, false;
   "v2_failure_bad_error", v2_failure_bad_error, false;
   "v2_failure_no_data", v2_failure_no_data, true;
   "v2_failure_bad_code", v2_failure_bad_code, false;
   "v2_failure_bad_message", v2_failure_bad_message, false;
+]
+
+let tests_response_plus = [
+  "v2_success_with_junk", v2_success_with_junk, true;
 ]
 
 let invoke parse_func (test_name, json, pass) =
@@ -175,6 +195,8 @@ let test tcs unmarshal () =
 
 let tests =
   [ "Jsonrpc.of_string", `Quick, test tests_json Jsonrpc.of_string
+  ; "Jsonrpc.of_string ~strict:false", `Quick, test tests_json_plus (Jsonrpc.of_string ~strict:false)
   ; "Jsonrpc.call_of_string", `Quick, test tests_call Jsonrpc.call_of_string
   ; "Jsonrpc.response_of_string", `Quick, test tests_response Jsonrpc.response_of_string
+  ; "Jsonrpc.response_of_string ~strict:false", `Quick, test tests_response_plus (Jsonrpc.response_of_string ~strict:false)
   ]


### PR DESCRIPTION
There is need to just retrieve the valid json from the input string,
and convert the json to RPC object. Tailing junks need to be ignored
to enhance robustness of the application. Without the changes, user
need to parse the input using some json parser, and then make the
string (according to the parser) to be parsed again here in Yojson
inside jsonrpc, which makes the API inefficient to user.

Signed-off-by: YarsinCitrix <yarsin.he@citrix.com>