### PR TITLE
New Rpc.Types variants for 3- and 4-tuples

### DIFF
--- a/ppx/ppx_deriving_rpcty.cppo.ml
+++ b/ppx/ppx_deriving_rpcty.cppo.ml
@@ -81,9 +81,14 @@ module Typ_of = struct
         [%expr List [%e expr_of_typ  typ]]
       | [%type: [%t? typ] array] ->
         [%expr Array [%e expr_of_typ  typ]]
-      | {ptyp_desc = Ptyp_tuple typs; _ } ->
-        let typs = List.rev typs in
-        List.fold_right (fun t acc -> [%expr Tuple ([%e expr_of_typ  t], [%e acc])]) (List.rev (List.tl typs)) [%expr [%e (expr_of_typ  (List.hd typs))] ]
+      | {ptyp_desc = Ptyp_tuple [t1;t2]; _ } ->
+        [%expr Tuple ([%e expr_of_typ t1], [%e expr_of_typ t2])]
+      | {ptyp_desc = Ptyp_tuple [t1;t2;t3]; _ } ->
+        [%expr Tuple3 ([%e expr_of_typ t1], [%e expr_of_typ t2], [%e expr_of_typ t3])]
+      | {ptyp_desc = Ptyp_tuple [t1;t2;t3;t4]; _ } ->
+        [%expr Tuple4 ([%e expr_of_typ t1], [%e expr_of_typ t2], [%e expr_of_typ t3], [%e expr_of_typ t4])]
+      | {ptyp_desc = Ptyp_tuple _; _ } ->
+        failwith "Tuples with arity > 4 are not supported"
       | [%type: [%t? typ] option] ->
         [%expr Option [%e expr_of_typ typ]]
       | { ptyp_desc = Ptyp_constr ( { txt = lid; _ }, _ ); _ } ->
@@ -191,10 +196,11 @@ module Typ_of = struct
               in
               let contents = match typs with
                 | [] -> [%expr Unit]
-                | typs_hd::typs_tl -> List.fold_right (fun t acc ->
-                    [%expr Tuple ([%e expr_of_typ  t], [%e acc])])
-                    typs_tl
-                    [%expr [%e (expr_of_typ  typs_hd)]]
+                | [t1] -> expr_of_typ t1
+                | [t1;t2] -> [%expr Tuple ([%e expr_of_typ t1], [%e expr_of_typ t2])]
+                | [t1;t2;t3] -> [%expr Tuple3 ([%e expr_of_typ t1], [%e expr_of_typ t2], [%e expr_of_typ t3])]
+                | [t1;t2;t3;t4] -> [%expr Tuple4 ([%e expr_of_typ t1], [%e expr_of_typ t2], [%e expr_of_typ t3], [%e expr_of_typ t4])]
+                | _ -> failwith "Tuples with arity > 4 are not supported"
               in
               let args = List.mapi (fun i _ -> evar (argn i)) typs in
               let pattern = List.mapi (fun i _ -> pvar (argn i)) typs in

--- a/src/html/htmlgen.ml
+++ b/src/html/htmlgen.ml
@@ -28,6 +28,8 @@ let rec html_of_t : type a.a typ -> string list =
   | Unit -> print "unit"
   | Option x -> html_of_t x @ (print " option")
   | Tuple (a, b) -> html_of_t a @ (print " * ") @ (html_of_t b)
+  | Tuple3 (a,b,c) -> html_of_t a @ (print " * " ) @ (html_of_t b) @ (print " * ") @ (html_of_t c)
+  | Tuple4 (a,b,c,d) -> html_of_t a @ (print " * " ) @ (html_of_t b) @ (print " * ") @ (html_of_t c) @ (print " * ") @ (html_of_t d)
   | Abstract _ -> print "<abstract>"
 
 (* Function inputs and outputs in a table *)

--- a/src/lib/cmdlinergen.ml
+++ b/src/lib/cmdlinergen.ml
@@ -90,6 +90,8 @@ module Gen () = struct
         (Cmdliner.Arg.(required & pos (incr ()) (some string) None & pinfo))
     | Option _ -> Term.(const Rpc.Null)
     | Tuple _ -> Term.const Rpc.Null
+    | Tuple3 _ -> Term.const Rpc.Null
+    | Tuple4 _ -> Term.const Rpc.Null
     | Struct _ ->
       Term.app
         (Term.pure (fun x ->

--- a/src/lib/markdowngen.ml
+++ b/src/lib/markdowngen.ml
@@ -40,6 +40,8 @@ let rec string_of_t : type a.a typ -> string list =
   | Unit -> print "unit"
   | Option x -> string_of_t x @ (print " option")
   | Tuple (a, b) -> string_of_t a @ (print " * ") @ (string_of_t b)
+  | Tuple3 (a, b, c) -> string_of_t a @ (print " * ") @ (string_of_t b) @ (print " * ") @ (string_of_t c)
+  | Tuple4 (a, b, c, d) -> string_of_t a @ (print " * ") @ (string_of_t b) @ (print " * ") @ (string_of_t c) @ (print " * ") @ (string_of_t d)
   | Abstract _ -> print "<abstract>"
 
 let definition_of_t : type a.a typ -> string list = function
@@ -68,6 +70,8 @@ let rec ocaml_patt_of_t : type a. a typ -> string = fun ty ->
   | Unit -> "()"
   | Option x -> Printf.sprintf "%s_opt" (ocaml_patt_of_t x)
   | Tuple (a, b) -> Printf.sprintf "(%s,%s)" (ocaml_patt_of_t a) (ocaml_patt_of_t b)
+  | Tuple3 (a, b, c) -> Printf.sprintf "(%s,%s,%s)" (ocaml_patt_of_t a) (ocaml_patt_of_t b) (ocaml_patt_of_t c)
+  | Tuple4 (a, b, c, d) -> Printf.sprintf "(%s,%s,%s,%s)" (ocaml_patt_of_t a) (ocaml_patt_of_t b) (ocaml_patt_of_t c) (ocaml_patt_of_t d)
   | Abstract _ -> "abstract"
 
 let rpc_of : type a. a typ -> string -> Rpc.t = fun ty hint ->
@@ -301,6 +305,8 @@ let expand_types is =
       | Dict (_, ty) -> expand ty
       | Option ty -> expand ty
       | Tuple (ty1, ty2) -> (expand ty1) @ (expand ty2)
+      | Tuple3 (ty1, ty2, ty3) -> (expand ty1) @ (expand ty2) @ (expand ty3)
+      | Tuple4 (ty1, ty2, ty3, ty4) -> (expand ty1) @ (expand ty2) @ (expand ty3) @ (expand ty4)
       | Struct { fields; _ } -> List.map (function BoxedField field -> expand field.field) fields |> List.flatten
       | Variant { variants; _ } -> List.map (function BoxedTag tag -> expand tag.tcontents) variants |> List.flatten
       | _ -> []

--- a/src/lib/pythongen.ml
+++ b/src/lib/pythongen.ml
@@ -236,10 +236,29 @@ let rec typecheck : type a.a typ -> string -> t list = fun ty v ->
     [
       Line (sprintf "if not (isinstance(%s, tuple) and len(%s) == 2):" v v);
       Block [ raise_type_error ];
-      Line (sprintf "left, right = %s" v)
+      Line (sprintf "v1, v2 = %s" v)
     ] @
-    typecheck a (Printf.sprintf "left") @
-    typecheck b (Printf.sprintf "right")
+    typecheck a (Printf.sprintf "v1") @
+    typecheck b (Printf.sprintf "v2")
+  | Tuple3 (a, b, c) ->
+    [
+      Line (sprintf "if not (isinstance(%s, tuple) and len(%s) == 3):" v v);
+      Block [ raise_type_error ];
+      Line (sprintf "v1, v2, v3 = %s" v)
+    ] @
+    typecheck a (Printf.sprintf "v1") @
+    typecheck b (Printf.sprintf "v2") @
+    typecheck c (Printf.sprintf "v3")
+  | Tuple4 (a, b, c, d) ->
+    [
+      Line (sprintf "if not (isinstance(%s, tuple) and len(%s) == 4):" v v);
+      Block [ raise_type_error ];
+      Line (sprintf "v1, v2, v3, v4 = %s" v)
+    ] @
+    typecheck a (Printf.sprintf "v1") @
+    typecheck b (Printf.sprintf "v2") @
+    typecheck c (Printf.sprintf "v3") @
+    typecheck d (Printf.sprintf "v4")
   | Abstract _ ->
     failwith "Abstract types cannot be typechecked by pythongen"
 
@@ -268,6 +287,8 @@ let rec value_of : type a. a typ -> string =
     | Unit -> "None"
     | Option _ -> "None"
     | Tuple _ -> "[]"
+    | Tuple3 _ -> "[]"
+    | Tuple4 _ -> "[]"
     | Abstract _ -> failwith "Cannot get default value for abstract types"
 
 

--- a/src/lib/rpc.ml
+++ b/src/lib/rpc.ml
@@ -60,6 +60,8 @@ module Types = struct
     | Unit : unit typ
     | Option : 'a typ -> 'a option typ
     | Tuple : 'a typ * 'b typ -> ('a * 'b) typ
+    | Tuple3 : 'a typ * 'b typ * 'c typ -> ('a * 'b * 'c) typ
+    | Tuple4 : 'a typ * 'b typ * 'c typ * 'd typ -> ('a * 'b * 'c * 'd) typ
     | Struct : 'a structure -> 'a typ
     | Variant : 'a variant -> 'a typ
     | Abstract : 'a abstract -> 'a typ

--- a/src/lib/rpc.mli
+++ b/src/lib/rpc.mli
@@ -55,6 +55,8 @@ module Types : sig
     | Unit : unit typ
     | Option : 'a typ -> 'a option typ
     | Tuple : 'a typ * 'b typ -> ('a * 'b) typ
+    | Tuple3 : 'a typ * 'b typ * 'c typ -> ('a * 'b * 'c) typ
+    | Tuple4 : 'a typ * 'b typ * 'c typ * 'd typ -> ('a * 'b * 'c * 'd) typ
     | Struct : 'a structure -> 'a typ
     | Variant : 'a variant -> 'a typ
     | Abstract : 'a abstract -> 'a typ

--- a/tests/ppx/test_deriving_rpcty.ml
+++ b/tests/ppx/test_deriving_rpcty.ml
@@ -80,9 +80,13 @@ type test_tuple2 = (int * string) [@@deriving rpcty]
 let test_tuple2 () =
   check_marshal_unmarshal ((3, "hello"), Rpc.Enum [Rpc.Int 3L; Rpc.String "hello"], typ_of_test_tuple2)
 
-(*type test_tuple3 = (int * string * char) [@@deriving rpcty]
+type test_tuple3 = (int * string * char) [@@deriving rpcty]
 let test_tuple3 () =
-  check_marshal_unmarshal ((3, "hi", 'c'), Rpc.Enum [Rpc.Int 3L; Rpc.String "hi"; Rpc.Int (Char.code 'c' |> Int64.of_int)], typ_of_test_tuple3)*)
+  check_marshal_unmarshal ((3, "hi", 'c'), Rpc.Enum [Rpc.Int 3L; Rpc.String "hi"; Rpc.Int (Char.code 'c' |> Int64.of_int)], typ_of_test_tuple3)
+
+type test_tuple4 = (int * string * char * bool) [@@deriving rpcty]
+let test_tuple4 () =
+  check_marshal_unmarshal ((3, "hi", 'c', true), Rpc.Enum [Rpc.Int 3L; Rpc.String "hi"; Rpc.Int (Char.code 'c' |> Int64.of_int); Rpc.Bool true], typ_of_test_tuple4)
 
 type test_option = int option [@@deriving rpcty]
 let test_option () =
@@ -206,6 +210,24 @@ let test_defaults_bad () =
   | Ok _ -> Alcotest.fail "Should have had an error"
   | Error _ -> ()
 
+type varianttest =
+  | Banana of string option * string list
+  | Carrot of int * string * float
+  | Beetroot of int * string * float * bool
+  [@@deriving rpcty]
+
+let test_multiple_args () =
+  let (x : varianttest) = Banana (Some "foo", ["hello"]) in
+  check_marshal_unmarshal (x, Rpc.(Enum [String "Banana"; Enum [Enum[String "foo"]; Enum[String "hello"]]]), (typ_of_varianttest))
+
+let test_multiple_args3 () =
+  let (x : varianttest) = Carrot (1,"two",3.0) in
+  check_marshal_unmarshal (x, Rpc.(Enum [String "Carrot"; Enum [Int 1L; String "two"; Float 3.0]]), (typ_of_varianttest))
+
+let test_multiple_args4 () =
+  let (x : varianttest) = Beetroot (6,"seven",8.0,true) in
+  check_marshal_unmarshal (x, Rpc.(Enum [String "Beetroot"; Enum [Int 6L; String "seven"; Float 8.0; Bool true]]), (typ_of_varianttest))
+
 let tests =
   [ "int", `Quick, test_int
   ; "int_from_string", `Quick, test_int_from_string
@@ -234,7 +256,8 @@ let tests =
   ; "int list", `Quick, test_int_list
   ; "int array", `Quick, test_int_array
   ; "tuple2", `Quick, test_tuple2
-    (*    "tuple3", `Quick, test_tuple3;*)
+  ; "tuple3", `Quick, test_tuple3
+  ; "tuple4", `Quick, test_tuple4
   ; "option", `Quick, test_option
   ; "option (none)", `Quick, test_option_none
   ; "bad_option", `Quick, test_bad_option
@@ -261,4 +284,7 @@ let tests =
   ; "defaults_var", `Quick, test_defaults_var
   ; "defaults_bad", `Quick, test_defaults_bad
   ; "dict", `Quick, test_dict_key
+  ; "multiple_args", `Quick, test_multiple_args
+  ; "multiple_args3", `Quick, test_multiple_args3
+  ; "multiple_args4", `Quick, test_multiple_args4
   ]


### PR DESCRIPTION
Previously both of these types just wouldn't work. It now also
fails with a clear error message when you try to use 5- and more
tuples.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>