### PR TITLE
Rpc: correctly marshal int, int32 and int64

### DIFF
--- a/src/lib/rpc.ml
+++ b/src/lib/rpc.ml
@@ -173,7 +173,7 @@ let rpc_of_t x = x
 
 let rpc_of_int64 i = Int64 i
 
-let rpc_of_int32 i = Int32 (Int64.of_int32 i)
+let rpc_of_int32 i = Int32 i
 
 let rpc_of_int i = Int (Int64.of_int i)
 

--- a/src/lib/rpc.ml
+++ b/src/lib/rpc.ml
@@ -171,7 +171,7 @@ let rec to_string t =
 
 let rpc_of_t x = x
 
-let rpc_of_int64 i = Int64 i
+let rpc_of_int64 i = Int i
 
 let rpc_of_int32 i = Int32 i
 

--- a/src/lib/rpc.ml
+++ b/src/lib/rpc.ml
@@ -171,9 +171,9 @@ let rec to_string t =
 
 let rpc_of_t x = x
 
-let rpc_of_int64 i = Int i
+let rpc_of_int64 i = Int64 i
 
-let rpc_of_int32 i = Int (Int64.of_int32 i)
+let rpc_of_int32 i = Int32 (Int64.of_int32 i)
 
 let rpc_of_int i = Int (Int64.of_int i)
 

--- a/tests/ppx/test_deriving_rpc.ml
+++ b/tests/ppx/test_deriving_rpc.ml
@@ -45,7 +45,7 @@ let test_bad_int_string () =
 type test_int32 = int32 [@@deriving rpc]
 
 let test_int32 () =
-  check_marshal_unmarshal (1l, Rpc.Int 1L, rpc_of_test_int32, test_int32_of_rpc)
+  check_marshal_unmarshal (1l, Rpc.Int32 1l, rpc_of_test_int32, test_int32_of_rpc)
 
 let test_int32_from_string () =
   check_unmarshal_ok Alcotest.int32 test_int32_of_rpc 1l (Rpc.String "1")

--- a/tests/ppx/test_deriving_rpcty.ml
+++ b/tests/ppx/test_deriving_rpcty.ml
@@ -47,7 +47,7 @@ let test_bad_int_string () =
 
 type test_int32 = int32 [@@deriving rpcty]
 
-let test_int32 () = check_marshal_unmarshal (1l, Rpc.Int 1L, typ_of_test_int32)
+let test_int32 () = check_marshal_unmarshal (1l, Rpc.Int32 1l, typ_of_test_int32)
 
 let test_int32_from_string () =
   check_unmarshal_ok 1l typ_of_test_int32 (Rpc.String "1")


### PR DESCRIPTION
I fear that something may be using it as an involuntary feature, but it is wrong. This should fix #128