### PR TITLE
xmlrpc: marshal integer values using an <int> tag

### DIFF
--- a/src/lib/xmlrpc.ml
+++ b/src/lib/xmlrpc.ml
@@ -37,9 +37,9 @@ let encode =
 let rec add_value f = function
   | Null -> f "<value><nil/></value>"
   | Int i ->
-      f "<value><int>" ;
+      f "<value><i8>" ;
       f (Int64.to_string i) ;
-      f "</int></value>"
+      f "</i8></value>"
   | Int32 i ->
       f "<value><i4>" ;
       f (Int32.to_string i) ;

--- a/src/lib/xmlrpc.ml
+++ b/src/lib/xmlrpc.ml
@@ -37,9 +37,9 @@ let encode =
 let rec add_value f = function
   | Null -> f "<value><nil/></value>"
   | Int i ->
-      f "<value>" ;
+      f "<value><int>" ;
       f (Int64.to_string i) ;
-      f "</value>"
+      f "</int></value>"
   | Int32 i ->
       f "<value><i4>" ;
       f (Int32.to_string i) ;

--- a/src/lib/xmlrpc.mli
+++ b/src/lib/xmlrpc.mli
@@ -1,16 +1,16 @@
 val encode : string -> string
 
-val to_string : Rpc.t -> string
+val to_string : ?strict:bool -> Rpc.t -> string
 
-val to_a : empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a
+val to_a : ?strict:bool -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.t -> 'a
   [@@ocaml.deprecated]
 
-val string_of_call : Rpc.call -> string
+val string_of_call : ?strict:bool -> Rpc.call -> string
 
 val string_of_response : Rpc.response -> string
 
 val a_of_response :
-  empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a
+  ?strict:bool -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a
   [@@ocaml.deprecated]
 
 exception Parse_error of string * string * Xmlm.input

--- a/src/lib/xmlrpc.mli
+++ b/src/lib/xmlrpc.mli
@@ -7,7 +7,7 @@ val to_a : ?strict:bool -> empty:(unit -> 'a) -> append:('a -> string -> unit) -
 
 val string_of_call : ?strict:bool -> Rpc.call -> string
 
-val string_of_response : Rpc.response -> string
+val string_of_response : ?strict:bool -> Rpc.response -> string
 
 val a_of_response :
   ?strict:bool -> empty:(unit -> 'a) -> append:('a -> string -> unit) -> Rpc.response -> 'a

--- a/tests/lib/encoding.ml
+++ b/tests/lib/encoding.ml
@@ -4,12 +4,25 @@ let run () =
   Printf.printf "r = %s\n%!" (Rpc.to_string r) ;
   let t' = Rpc.string_of_rpc r in
   Printf.printf "t = t : %b'\n%!" (t = t') ;
-  assert (t = t') ;
-  let test = Rpc.Dict [("foo", String "&")] in
-  let str = Xmlrpc.to_string test in
+  assert (t = t')
+
+let run_not_strict () =
+  let test = Rpc.Dict [("foo", Rpc.String "&"); ("bar", Rpc.Int (Int64.of_int 3))] in
+  let str = Xmlrpc.to_string ~strict:false test in
   assert (
     str
-    = "<value><struct><member><name>foo</name><value>&amp;</value></member></struct></value>"
+    = "<value><struct><member><name>foo</name><value>&amp;</value></member><member><name>bar</name><value>3</value></member></struct></value>"
    )
 
-let tests = [("test", `Quick, run)]
+let run_strict () =
+  let test = Rpc.Dict [("foo", Rpc.String "&"); ("bar", Rpc.Int (Int64.of_int 3))] in
+  let str = Xmlrpc.to_string ~strict:true test in
+  assert (
+    str
+    = "<value><struct><member><name>foo</name><value>&amp;</value></member><member><name>bar</name><value><i8>3</i8></value></member></struct></value>"
+   )
+
+let tests = [
+  ("test", `Quick, run);
+  ("test not strict", `Quick, run_not_strict);
+  ("test strict", `Quick, run_strict)]


### PR DESCRIPTION
This should fix #128. And is more compliant with the standard. Compare it with 
https://github.com/mirage/ocaml-rpc/pull/130