### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/rpc.opam
+++ b/rpc.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-rpc/rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "rpclib" {>= "5.0.0"}
   "rpclib-async" {>= "5.0.0"}
   "rpclib-lwt" {>= "5.0.0"}

--- a/rpclib-async.opam
+++ b/rpclib-async.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml"
   "alcotest" {with-test}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "rpclib" {>= "5.0.0"}
   "async"
 ]

--- a/rpclib-html.opam
+++ b/rpclib-html.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/ocaml-rpc/rpclib-html"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml"
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "rpclib" {>= "5.0.0"}
   "cow"
 ]

--- a/rpclib-js.opam
+++ b/rpclib-js.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-rpc/rpclib-js"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml"
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "rpclib" {>= "5.0.0"}
   "js_of_ocaml" {>= "3.3.0"}
   "js_of_ocaml-ppx" {>= "3.3.0"}

--- a/rpclib-lwt.opam
+++ b/rpclib-lwt.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml"
   "alcotest" {with-test}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "rpclib" {>= "5.0.0"}
   "lwt" {>= "3.0.0"}
   "alcotest-lwt" {with-test}

--- a/rpclib.opam
+++ b/rpclib.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
   "ocaml" {>= "4.04.0"}
   "alcotest" {with-test}
-  "dune" {build & >= "1.1.0"}
+  "dune" {>= "1.1.0"}
   "cmdliner"
   "rresult"
   "xmlm"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.