### PR TITLE
Fixed ppx to support Ocaml 4.09.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ env:
         - PINS="rpclib.master:. rpclib-js.master:. rpclib-html.master:. rpclib-lwt.master:. rpclib-async.master:. ppx_deriving_rpc.master:."
         - PACKAGE=rpc
     matrix:
-        - OCAML_VERSION=4.06.0 PRE_INSTALL_HOOK="sudo apt-get update -y; sudo apt-get install -y pylint pycodestyle"
+        - OCAML_VERSION=4.08.0 PRE_INSTALL_HOOK="sudo apt-get update -y; sudo apt-get install -y pylint pycodestyle"
         # We install the packages required by the unit test for linting the generated Python code in PRE_INSTALL_HOOK:
-        - PACKAGE=rpclib OCAML_VERSION=4.06.0
-        - PACKAGE=ppx_deriving_rpc OCAML_VERSION=4.06.0
-        - OCAML_VERSION=4.05.0 PRE_INSTALL_HOOK="sudo apt-get update -y; sudo apt-get install -y pylint pycodestyle"
-        - OCAML_VERSION=4.04.2 PRE_INSTALL_HOOK="sudo apt-get update -y; sudo apt-get install -y pylint pycodestyle"
+        - PACKAGE=rpclib OCAML_VERSION=4.08.0
+        - PACKAGE=ppx_deriving_rpc OCAML_VERSION=4.08.0
 matrix:
     fast_finish: true

--- a/ppx/common.ml
+++ b/ppx/common.ml
@@ -159,7 +159,8 @@ let convert_doc x = split x |> List.map ~f:(String.strip ~drop:(function | '\n' 
     ocamldoc docstrings and return them instead. In both cases, the result is an expression of
     type list *)
 let get_doc ~loc rpcdoc (attrs : attributes) =
-  let ocamldoc = attr loc "ocaml.doc" attrs in
+  let attr_list = List.map attrs ~f:(fun a -> (a.attr_name, a.attr_payload)) in
+  let ocamldoc = attr loc "ocaml.doc" attr_list in
   match rpcdoc, ocamldoc with
   | Some e, _ -> e
   | _, Some s -> elist ~loc (convert_doc s |> List.map ~f:(estring ~loc))

--- a/ppx_deriving_rpc.opam
+++ b/ppx_deriving_rpc.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.08.0"}
   "jbuilder" {build}
   "rpclib" {>= "5.0.0"}
   "rresult"

--- a/ppx_deriving_rpc.opam
+++ b/ppx_deriving_rpc.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/ppx_deriving_rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.09.0"}
   "jbuilder" {build}
   "rpclib" {>= "5.0.0"}
   "rresult"

--- a/rpc.opam
+++ b/rpc.opam
@@ -13,7 +13,7 @@ depends: [
   "rpclib-async" {>= "5.0.0"}
   "rpclib-lwt" {>= "5.0.0"}
   "ppx_deriving_rpc" {>= "5.0.0"}
-  "async" {>= "v0.9.0" & <= "v0.11.0"}
+  "async" {>= "v0.9.0" & <= "v0.13.0"}
   "lwt"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}

--- a/rpc.opam
+++ b/rpc.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.09.0"}
   "dune" {>= "1.1.0"}
   "rpclib" {>= "5.0.0"}
   "rpclib-async" {>= "5.0.0"}

--- a/rpc.opam
+++ b/rpc.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpc"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.1.0"}
   "rpclib" {>= "5.0.0"}
   "rpclib-async" {>= "5.0.0"}

--- a/rpclib.opam
+++ b/rpclib.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpclib"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.09.0"}
   "alcotest" {with-test}
   "dune" {>= "1.1.0"}
   "cmdliner"

--- a/rpclib.opam
+++ b/rpclib.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/ocaml-rpc"
 doc: "https://mirage.github.io/ocaml-rpc/rpclib"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 depends: [
-  "ocaml" {>= "4.09.0"}
+  "ocaml" {>= "4.08.0"}
   "alcotest" {with-test}
   "dune" {>= "1.1.0"}
   "cmdliner"


### PR DESCRIPTION
A number of breaking changes have been done in the Parsetree module of Ocaml, so the ppx had to be modified. Sadly, backwards compatibility would be cumbersome to achieve (the type constructors used here are different).