### PR TITLE
Incremented the upper bound for async's version.

### DIFF
--- a/rpc.opam
+++ b/rpc.opam
@@ -13,7 +13,7 @@ depends: [
   "rpclib-async" {>= "5.0.0"}
   "rpclib-lwt" {>= "5.0.0"}
   "ppx_deriving_rpc" {>= "5.0.0"}
-  "async" {>= "v0.9.0" & <= "v0.11.0"}
+  "async" {>= "v0.9.0" & <= "v0.12.0"}
   "lwt"
   "alcotest" {with-test}
   "alcotest-lwt" {with-test}


### PR DESCRIPTION
I incremented the upper bound for async's version because it compiles well, and allows compatibility with OCaml 4.09.0 (which is not compatible with async v0.11.0).