### PR TITLE
Added the possibility of having null as params in a request for JSON-RPC

### DIFF
--- a/src/lib/idl.ml
+++ b/src/lib/idl.ml
@@ -118,14 +118,15 @@ let get_arg call has_named name is_opt =
     match unnamed with
     | head :: tail ->
         Result.Ok (head, {call with Rpc.params= Rpc.Dict named :: tail})
-    | _ -> Result.Error (`Msg "Incorrect number of arguments") )
+    | _ -> Result.Error (`Msg "Incorrect number of argumentss") )
   | true, _, _ ->
       Result.Error
         (`Msg
           "Marshalling error: Expecting dict as first argument when named \
            parameters exist")
   | false, None, head :: tail -> Result.Ok (head, {call with Rpc.params= tail})
-  | false, None, [] -> Result.Error (`Msg "Incorrect number of arguments")
+  | false, None, [] -> Result.Ok (Null, call)
+    (* don't understand this one : Result.Error (`Msg "Incorrect number of arguments") *)
   | false, Some _, _ -> failwith "Can't happen by construction"
 
 module Make (M : MONAD) = struct

--- a/src/lib/idl.ml
+++ b/src/lib/idl.ml
@@ -118,7 +118,7 @@ let get_arg call has_named name is_opt =
     match unnamed with
     | head :: tail ->
         Result.Ok (head, {call with Rpc.params= Rpc.Dict named :: tail})
-    | _ -> Result.Error (`Msg "Incorrect number of argumentss") )
+    | _ -> Result.Error (`Msg "Incorrect number of arguments") )
   | true, _, _ ->
       Result.Error
         (`Msg
@@ -126,7 +126,6 @@ let get_arg call has_named name is_opt =
            parameters exist")
   | false, None, head :: tail -> Result.Ok (head, {call with Rpc.params= tail})
   | false, None, [] -> Result.Ok (Null, call)
-    (* don't understand this one : Result.Error (`Msg "Incorrect number of arguments") *)
   | false, Some _, _ -> failwith "Can't happen by construction"
 
 module Make (M : MONAD) = struct

--- a/src/lib/jsonrpc.ml
+++ b/src/lib/jsonrpc.ml
@@ -189,7 +189,7 @@ let version_id_and_call_of_string_option str =
                      "Invalid field 'params' in request body") )
           | V2 ->
             match get' "params" d with
-            | None -> []
+            | None | Some Null -> []
             | Some (Enum l) -> l
             | Some (Dict l) -> [Dict l]
             | _ ->
@@ -199,12 +199,12 @@ let version_id_and_call_of_string_option str =
         in
         let id =
           match get' "id" d with
+          | None | Some Null -> None (* is a notification *)
           | Some (Int a) -> Some (Int a)
           | Some (String a) -> Some (String a)
           | Some _ -> 
             raise
               (Malformed_method_request "Invalid field 'id' in request body")
-          | None -> None (* is a notification *)
         in
         let c = call name params in
         (version, id, {c with notif = id == None})

--- a/src/lib/jsonrpc.ml
+++ b/src/lib/jsonrpc.ml
@@ -226,7 +226,7 @@ let version_id_and_call_of_string s =
   | None    -> raise (Malformed_method_request "Invalid field 'id' in request body")
 
 let call_of_string str =
-  let _, _, call = version_id_and_call_of_string_option str in
+  let _, _, call = version_id_and_call_of_string str in
   call
 
 (* This functions parses the json and tries to extract a valid jsonrpc response

--- a/src/lib/jsonrpc.ml
+++ b/src/lib/jsonrpc.ml
@@ -226,7 +226,7 @@ let version_id_and_call_of_string s =
   | None    -> raise (Malformed_method_request "Invalid field 'id' in request body")
 
 let call_of_string str =
-  let _, _, call = version_id_and_call_of_string str in
+  let _, _, call = version_id_and_call_of_string_option str in
   call
 
 (* This functions parses the json and tries to extract a valid jsonrpc response


### PR DESCRIPTION
When toying with emacs' lsp-mode (it uses JSON-RPC as a transport protocol), I discovered it prefered to send a request with params equal to null than discarding the field, so we should take care of this case too.