### PR TITLE
Added the possibility of null params for option types

### DIFF
--- a/src/lib/rpcmarshal.ml
+++ b/src/lib/rpcmarshal.ml
@@ -64,6 +64,7 @@ let rec unmarshal : type a. a typ -> Rpc.t -> (a, err) Result.result =
   | Unit -> unit_of_rpc v
   | Option t -> (
     match v with
+    | Enum [Null] -> return None
     | Enum [x] -> unmarshal t x >>= fun x -> return (Some x)
     | Enum [] -> return None
     | y ->
@@ -119,8 +120,9 @@ let rec unmarshal : type a. a typ -> Rpc.t -> (a, err) Result.result =
                  match ty with
                  | Option x -> (
                    try
-                     List.assoc s keys |> unmarshal x
-                     >>= fun o -> return (Some o)
+                     let z = List.assoc s keys in
+                     if z = Null then return None
+                     else unmarshal x z >>= fun o -> return (Some o)
                    with _ -> return None )
                  | y ->
                    try List.assoc s keys |> unmarshal y with Not_found ->


### PR DESCRIPTION
Hi all,

Experimenting lately my development with VSCode, I experimented that it can send null for any field, and ocaml-rpc doesn't support it. I propose here to support this feature at least for option types.

I'd like to write tests for that, but I don't know how to add them. Can you help me with it?