### PR TITLE
breaking: rename notif -> is_notification

### DIFF
--- a/src/lib/cmdlinergen.ml
+++ b/src/lib/cmdlinergen.ml
@@ -131,7 +131,7 @@ module Gen () = struct
                | Error _ -> failwith "Type error" ))
           Cmdliner.Arg.(required & pos (incr ()) (some string) None & pinfo)
 
-  let declare_ notif name desc_list ty =
+  let declare_ is_notification name desc_list ty =
     let generate rpc =
       let wire_name = Idl.get_wire_name !description name in
       let rec inner : type b.
@@ -166,7 +166,7 @@ module Gen () = struct
                 | _ -> Rpc.Dict named :: List.rev unnamed
               in
               let call' = Rpc.call wire_name args in
-              let call = { call' with notif = notif } in
+              let call = { call' with is_notification = is_notification } in
               let response = rpc call in
               match response.Rpc.contents with x ->
                 Printf.printf "%s\n" (Rpc.to_string x) ;

--- a/src/lib/codegen.ml
+++ b/src/lib/codegen.ml
@@ -7,7 +7,7 @@ type _ outerfn =
       -> ('a, 'b) Result.result outerfn
 
 module Method = struct
-  type 'a t = {name: string; description: string list; ty: 'a outerfn; notif : bool}
+  type 'a t = {name: string; description: string list; ty: 'a outerfn; is_notification : bool}
 
   let rec find_inputs : type a. a outerfn -> Idl.Param.boxed list =
    fun m ->
@@ -46,7 +46,7 @@ module Interface = struct
           (fun (BoxedFunction m) ->
             BoxedFunction
               Method.
-                {name= m.name; description= m.description; ty= prepend m.ty; notif=m.notif} )
+                {name= m.name; description= m.description; ty= prepend m.ty; is_notification= m.is_notification} )
           interface.methods }
 
   let setify l =
@@ -132,8 +132,8 @@ module Gen () = struct
 
   let ( @-> ) t f = Function (t, f)
 
-  let declare_ notif name description ty =
-    let m = BoxedFunction Method.{name; description; ty; notif = notif} in
+  let declare_ is_notification name description ty =
+    let m = BoxedFunction Method.{name; description; ty; is_notification = is_notification} in
     methods := m :: !methods
 
   let declare : string -> string list -> 'a fn -> 'a res =

--- a/src/lib/codegen.mli
+++ b/src/lib/codegen.mli
@@ -5,7 +5,7 @@ type _ outerfn =
       -> ('a, 'b) Result.result outerfn
 
 module Method : sig
-  type 'a t = {name: string; description: string list; ty: 'a outerfn; notif: bool}
+  type 'a t = {name: string; description: string list; ty: 'a outerfn; is_notification: bool}
 
   val find_inputs : 'a outerfn -> Idl.Param.boxed list
 

--- a/src/lib/jsonrpc.ml
+++ b/src/lib/jsonrpc.ml
@@ -96,7 +96,7 @@ let string_of_call ?(version= V1) call =
           [ ("jsonrpc", String "2.0")
           ; ("method", String call.name)
           ; ("params", params) ]
-  in let json = if not call.notif then json @ [ ("id", Int (new_id ())) ] else json in
+  in let json = if not call.is_notification then json @ [ ("id", Int (new_id ())) ] else json in
   to_string (Dict json)
 
 let json_of_response ?(id= Int 0L) version response =
@@ -209,7 +209,7 @@ let version_id_and_call_of_string_option str =
               (Malformed_method_request "Invalid field 'id' in request body")
         in
         let c = call name params in
-        (version, id, {c with notif = id == None})
+        (version, id, {c with is_notification = id == None})
     | _ -> raise (Malformed_method_request "Invalid request body")
   with
   | Missing_field field ->

--- a/src/lib/rpc.ml
+++ b/src/lib/rpc.ml
@@ -330,25 +330,25 @@ let struct_extend rpc default_rpc =
 
 type callback = string list -> t -> unit
 
-type call = {name: string; params: t list; notif: bool}
+type call = {name: string; params: t list; is_notification: bool}
 
-let call name params = {name; params; notif = false}
+let call name params = {name; params; is_notification = false}
 
-let notif name params = {name; params; notif = true}
+let notification name params = {name; params; is_notification = true}
 
 let string_of_call call =
   Printf.sprintf "-> %s(%s)" call.name
     (String.concat "," (List.map to_string call.params))
 
-type response = {success: bool; contents: t; notif: bool}
+type response = {success: bool; contents: t; is_notification: bool}
 
 let string_of_response response =
   Printf.sprintf "<- %s(%s)"
     (if response.success then "success" else "failure")
     (to_string response.contents)
 
-(* notif is to be set as true only if the call was a notification *)
+(* is_notification is to be set as true only if the call was a notification *)
 
-let success v = {success= true; contents= v; notif=false}
+let success v = {success= true; contents= v; is_notification= false}
 
-let failure v = {success= false; contents= v; notif=false}
+let failure v = {success= false; contents= v; is_notification= false}

--- a/src/lib/rpc.mli
+++ b/src/lib/rpc.mli
@@ -208,17 +208,17 @@ end
 
 type callback = string list -> t -> unit
 
-type call = {name: string; params: t list; notif: bool}
+type call = {name: string; params: t list; is_notification: bool}
 
 val call : string -> t list -> call
 
-val notif : string -> t list -> call
+val notification : string -> t list -> call
 
 val string_of_call : call -> string
 
 (** {2 Responses} *)
 
-type response = {success: bool; contents: t; notif: bool}
+type response = {success: bool; contents: t; is_notification: bool}
 
 val string_of_response : response -> string
 


### PR DESCRIPTION
To avoid parsing it as 'not if'. There was also a suggestion to call it `response_needed` in a discussion which I have lost, but `is_notification` keeps it closer to the specs which call it `notification`.

Ping @psafont @vycastor 

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>