### PR TITLE
Make ppx_deriving_rpc compatible with ppxlib.0.18.0

### DIFF
--- a/ppx/common.ml
+++ b/ppx/common.ml
@@ -234,8 +234,8 @@ module Attrs = struct
     Attribute.declare
       "rpc.name"
       context
-      Ast_pattern.(pstr (pstr_eval (pexp_constant (pconst_string __ none)) nil ^:: nil))
-      (fun x -> x)
+      Ast_pattern.(pstr (pstr_eval (pexp_constant (pconst_string __ __ none)) nil ^:: nil))
+      (fun x _loc -> x)
 
 
   let constr_name = name Attribute.Context.constructor_declaration
@@ -245,8 +245,8 @@ module Attrs = struct
     Attribute.declare
       "rpc.key"
       Attribute.Context.label_declaration
-      Ast_pattern.(pstr (pstr_eval (pexp_constant (pconst_string __ none)) nil ^:: nil))
-      (fun x -> x)
+      Ast_pattern.(pstr (pstr_eval (pexp_constant (pconst_string __ __ none)) nil ^:: nil))
+      (fun x _loc -> x)
 
 
   let is_dict =
@@ -259,13 +259,13 @@ end
    use the nice `Attributes` module and have to roll our own. *)
 let attr loc name attrs =
   let pat =
-    Ast_pattern.(pstr (pstr_eval (pexp_constant (pconst_string __ none)) __ ^:: nil))
+    Ast_pattern.(pstr (pstr_eval (pexp_constant (pconst_string __ __ none)) __ ^:: nil))
   in
   List.find_opt (fun { attr_name = { txt; _ }; _ } -> String.equal txt name) attrs
   |> Option.map (fun { attr_payload; _ } -> attr_payload)
   |> fun o ->
   Option.bind o (fun str ->
-      Ast_pattern.parse pat loc str ~on_error:(fun _ -> None) (fun str _ -> Some str))
+      Ast_pattern.parse pat loc str ~on_error:(fun _ -> None) (fun str _loc _ -> Some str))
 
 
 let split = string_split_on_chars ~on:[ '\n' ]

--- a/ppx/ppx_deriving_rpcty.ml
+++ b/ppx/ppx_deriving_rpcty.ml
@@ -297,7 +297,7 @@ module Typ_of = struct
           in
           let vconstructor_case =
             case
-              ~lhs:(ppat_constant (Pconst_string (lower_rpc_name, None)))
+              ~lhs:(pstring lower_rpc_name)
               ~guard:None
               ~rhs:
                 [%expr

--- a/ppx_deriving_rpc.opam
+++ b/ppx_deriving_rpc.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "rpclib" {= version}
   "rresult"
-  "ppxlib" {>= "0.9.0"}
+  "ppxlib" {>= "0.18.0"}
   "lwt" {with-test & >= "3.0.0"}
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
ppxlib.0.18.0 upgrades its internal AST to 4.11 resulting in a change in string constant representation. This PR makes ppx_deriving_rpc compatible with the latest ppxlib.

You will probably want to wait for the ppxlib release to go through before merging this!