### PR TITLE
Compatibility with rresult 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ will give two functions:
   `val rpc_of_t : t -> Rpc.t`
 
 * A function to convert values of type `Rpc.t` to values of type `t` :
-  `val t_of_rpc : Rpc.t -> (t,string) Result.result`
+  `val t_of_rpc : Rpc.t -> (t,string) Result.t`
 
 It also supports the `@key` annotations for having different field names:
 ```ocaml

--- a/example/example.ml
+++ b/example/example.ml
@@ -72,12 +72,12 @@ module Client = MyAPI (MyIdl.GenClient ())
 module Server = MyAPI (MyIdl.GenServer ())
 
 let _ =
-  (* The Client module generated above makes use of the Result.result type,
+  (* The Client module generated above makes use of the Result.t type,
      and hence it is convenient to use the Monadic `bind` and `return`
      functions in Rresult.R *)
   let open MyIdl in
   (* The server is used by associating the RPC declarations with their
-     implementations. The return type is expected to be Result.result, hence
+     implementations. The return type is expected to be Result.t, hence
      the use of `ok` here. *)
   Server.api1 (fun i s ->
       Printf.printf "Received '%d' and '%s': returning '%b'\n" i s true;
@@ -166,7 +166,7 @@ let vm_name_description : (string, vm) field =
 (* The constructor function here takes a 'field getter' argument. This is
    a record with a single field, `g`, with signature:
 
-       g: 'a. string -> 'a Types.typ -> ('a, Rresult.R.msg) Result.result
+       g: 'a. string -> 'a Types.typ -> ('a, Rresult.R.msg) Result.t
 
    this is used to obtain the values for each field. With this mechanism,
    the details of how each field value is obtained is up to the caller of the
@@ -324,7 +324,7 @@ let _ =
     if paused then return_err (Errors "Paused start is unimplemented") else return ()
   in
   VMServer.start impl;
-  (* And an implementation that raises exceptions rather than Result.result
+  (* And an implementation that raises exceptions rather than Result.t
      types *)
   let implexn _vm' paused =
     if paused then raise (ExampleExn (Errors "Paused start is unimplemented"));

--- a/src/async/rpc_async.mli
+++ b/src/async/rpc_async.mli
@@ -3,7 +3,7 @@ type server_implementation
 
 module T : sig
   type 'a box
-  type ('a, 'b) resultb = ('a, 'b) Result.result box
+  type ('a, 'b) resultb = ('a, 'b) Result.t box
   type rpcfn = Rpc.call -> Rpc.response Async.Deferred.t
 
   val lift : ('a -> 'b Async.Deferred.t) -> 'a -> 'b box

--- a/src/lib/cmdlinergen.ml
+++ b/src/lib/cmdlinergen.ml
@@ -6,7 +6,7 @@ module Gen () = struct
     -> ((Rpc.call -> Rpc.response) -> (unit -> unit) Cmdliner.Term.t * Cmdliner.Term.info)
        list
 
-  type ('a, 'b) comp = ('a, 'b) Result.result
+  type ('a, 'b) comp = ('a, 'b) Result.t
   type 'a rpcfn = Rpc.call -> Rpc.response
   type 'a res = unit
 

--- a/src/lib/codegen.ml
+++ b/src/lib/codegen.ml
@@ -2,7 +2,7 @@ open Rpc.Types
 
 type _ outerfn =
   | Function : 'a Idl.Param.t * 'b outerfn -> ('a -> 'b) outerfn
-  | Returning : ('a Idl.Param.t * 'b Idl.Error.t) -> ('a, 'b) Result.result outerfn
+  | Returning : ('a Idl.Param.t * 'b Idl.Error.t) -> ('a, 'b) Result.t outerfn
 
 module Method = struct
   type 'a t =
@@ -129,7 +129,7 @@ end
 exception Interface_not_described
 
 module Gen () = struct
-  type ('a, 'b) comp = ('a, 'b) Result.result
+  type ('a, 'b) comp = ('a, 'b) Result.t
   type 'a fn = 'a outerfn
   type 'a res = unit
   type implementation = unit -> Interface.t

--- a/src/lib/codegen.mli
+++ b/src/lib/codegen.mli
@@ -1,6 +1,6 @@
 type _ outerfn =
   | Function : 'a Idl.Param.t * 'b outerfn -> ('a -> 'b) outerfn
-  | Returning : ('a Idl.Param.t * 'b Idl.Error.t) -> ('a, 'b) Result.result outerfn
+  | Returning : ('a Idl.Param.t * 'b Idl.Error.t) -> ('a, 'b) Result.t outerfn
 
 module Method : sig
   type 'a t =
@@ -59,13 +59,13 @@ end
 exception Interface_not_described
 
 module Gen () : sig
-  type ('a, 'b) comp = ('a, 'b) Result.result
+  type ('a, 'b) comp = ('a, 'b) Result.t
   type 'a fn = 'a outerfn
   type 'a res = unit
   type implementation = unit -> Interface.t
 
   val implement : Interface.description -> implementation
-  val returning : 'a Idl.Param.t -> 'b Idl.Error.t -> ('a, 'b) Result.result outerfn
+  val returning : 'a Idl.Param.t -> 'b Idl.Error.t -> ('a, 'b) Result.t outerfn
   val ( @-> ) : 'a Idl.Param.t -> 'b outerfn -> ('a -> 'b) outerfn
   val declare : string -> string list -> 'a fn -> 'a res
   val declare_notification : string -> string list -> 'a fn -> 'a res

--- a/src/lib/idl.ml
+++ b/src/lib/idl.ml
@@ -130,7 +130,7 @@ let get_arg call has_named name is_opt =
 module Make (M : MONAD) = struct
   module type RPCTRANSFORMER = sig
     type 'a box
-    type ('a, 'b) resultb = ('a, 'b) Result.result box
+    type ('a, 'b) resultb = ('a, 'b) Result.t box
     type rpcfn = Rpc.call -> Rpc.response M.t
 
     val lift : ('a -> 'b M.t) -> 'a -> 'b box
@@ -144,7 +144,7 @@ module Make (M : MONAD) = struct
 
   module T = struct
     type 'a box = { box : 'a M.t }
-    type ('a, 'b) resultb = ('a, 'b) Result.result box
+    type ('a, 'b) resultb = ('a, 'b) Result.t box
     type rpcfn = Rpc.call -> Rpc.response M.t
 
     let lift f x = { box = f x }

--- a/src/lib/idl.mli
+++ b/src/lib/idl.mli
@@ -134,7 +134,7 @@ module Make (M : MONAD) : sig
 
   module type RPCTRANSFORMER = sig
     type 'a box
-    type ('a, 'b) resultb = ('a, 'b) Result.result box
+    type ('a, 'b) resultb = ('a, 'b) Result.t box
     type rpcfn = Rpc.call -> Rpc.response M.t
 
     val lift : ('a -> 'b M.t) -> 'a -> 'b box
@@ -180,7 +180,7 @@ module Make (M : MONAD) : sig
       function, which might send the RPC across the network, and returns a
       function of type 'a, in this case [(int -> string -> (bool, err) result)].
 
-      Our functions return a [Result.result] type, which contains
+      Our functions return a [Result.t] type, which contains
       the result of the Rpc, which might be an error message indicating
       a problem happening on the remote end. *)
   module GenClient () : sig

--- a/src/lib/rpc.ml
+++ b/src/lib/rpc.ml
@@ -91,13 +91,13 @@ module Types = struct
   and 'a boxed_field = BoxedField : ('a, 's) field -> 's boxed_field
 
   and field_getter =
-    { field_get : 'a. string -> 'a typ -> ('a, Rresult.R.msg) Result.result }
+    { field_get : 'a. string -> 'a typ -> ('a, Rresult.R.msg) Result.t }
 
   and 'a structure =
     { sname : string
     ; fields : 'a boxed_field list
     ; version : Version.t option
-    ; constructor : field_getter -> ('a, Rresult.R.msg) Result.result
+    ; constructor : field_getter -> ('a, Rresult.R.msg) Result.t
     }
 
   and ('a, 's) tag =
@@ -111,21 +111,21 @@ module Types = struct
 
   and 'a boxed_tag = BoxedTag : ('a, 's) tag -> 's boxed_tag
 
-  and tag_getter = { tget : 'a. 'a typ -> ('a, Rresult.R.msg) Result.result }
+  and tag_getter = { tget : 'a. 'a typ -> ('a, Rresult.R.msg) Result.t }
 
   and 'a variant =
     { vname : string
     ; variants : 'a boxed_tag list
     ; vdefault : 'a option
     ; vversion : Version.t option
-    ; vconstructor : string -> tag_getter -> ('a, Rresult.R.msg) Result.result
+    ; vconstructor : string -> tag_getter -> ('a, Rresult.R.msg) Result.t
     }
 
   and 'a abstract =
     { aname : string
     ; test_data : 'a list
     ; rpc_of : 'a -> t
-    ; of_rpc : t -> ('a, Rresult.R.msg) Result.result
+    ; of_rpc : t -> ('a, Rresult.R.msg) Result.t
     }
 
   let int = { name = "int"; ty = Basic Int; description = [ "Native integer" ] }

--- a/src/lib/rpc.mli
+++ b/src/lib/rpc.mli
@@ -85,13 +85,13 @@ module Types : sig
   and 'a boxed_field = BoxedField : ('a, 's) field -> 's boxed_field
 
   and field_getter =
-    { field_get : 'a. string -> 'a typ -> ('a, Rresult.R.msg) Result.result }
+    { field_get : 'a. string -> 'a typ -> ('a, Rresult.R.msg) Result.t }
 
   and 'a structure =
     { sname : string
     ; fields : 'a boxed_field list
     ; version : Version.t option
-    ; constructor : field_getter -> ('a, Rresult.R.msg) Result.result
+    ; constructor : field_getter -> ('a, Rresult.R.msg) Result.t
     }
 
   and ('a, 's) tag =
@@ -106,21 +106,21 @@ module Types : sig
 
   and 'a boxed_tag = BoxedTag : ('a, 's) tag -> 's boxed_tag
 
-  and tag_getter = { tget : 'a. 'a typ -> ('a, Rresult.R.msg) Result.result }
+  and tag_getter = { tget : 'a. 'a typ -> ('a, Rresult.R.msg) Result.t }
 
   and 'a variant =
     { vname : string
     ; variants : 'a boxed_tag list
     ; vdefault : 'a option
     ; vversion : Version.t option
-    ; vconstructor : string -> tag_getter -> ('a, Rresult.R.msg) Result.result
+    ; vconstructor : string -> tag_getter -> ('a, Rresult.R.msg) Result.t
     }
 
   and 'a abstract =
     { aname : string
     ; test_data : 'a list
     ; rpc_of : 'a -> t
-    ; of_rpc : t -> ('a, Rresult.R.msg) Result.result
+    ; of_rpc : t -> ('a, Rresult.R.msg) Result.t
     }
 
   val int : int def
@@ -160,17 +160,17 @@ val char_of_rpc : t -> char
 val unit_of_rpc : t -> unit
 
 module ResultUnmarshallers : sig
-  val int64_of_rpc : t -> (int64, Rresult.R.msg) Result.result
-  val int32_of_rpc : t -> (int32, Rresult.R.msg) Result.result
-  val int_of_rpc : t -> (int, Rresult.R.msg) Result.result
-  val bool_of_rpc : t -> (bool, Rresult.R.msg) Result.result
-  val float_of_rpc : t -> (float, Rresult.R.msg) Result.result
-  val string_of_rpc : t -> (string, Rresult.R.msg) Result.result
-  val dateTime_of_rpc : t -> (string, Rresult.R.msg) Result.result
-  val base64_of_rpc : t -> (string, Rresult.R.msg) Result.result
-  val t_of_rpc : t -> (t, Rresult.R.msg) Result.result
-  val unit_of_rpc : t -> (unit, Rresult.R.msg) Result.result
-  val char_of_rpc : t -> (char, Rresult.R.msg) Result.result
+  val int64_of_rpc : t -> (int64, Rresult.R.msg) Result.t
+  val int32_of_rpc : t -> (int32, Rresult.R.msg) Result.t
+  val int_of_rpc : t -> (int, Rresult.R.msg) Result.t
+  val bool_of_rpc : t -> (bool, Rresult.R.msg) Result.t
+  val float_of_rpc : t -> (float, Rresult.R.msg) Result.t
+  val string_of_rpc : t -> (string, Rresult.R.msg) Result.t
+  val dateTime_of_rpc : t -> (string, Rresult.R.msg) Result.t
+  val base64_of_rpc : t -> (string, Rresult.R.msg) Result.t
+  val t_of_rpc : t -> (t, Rresult.R.msg) Result.t
+  val unit_of_rpc : t -> (unit, Rresult.R.msg) Result.t
+  val char_of_rpc : t -> (char, Rresult.R.msg) Result.t
 end
 
 (** {2 Calls} *)

--- a/src/lib/rpc_genfake.ml
+++ b/src/lib/rpc_genfake.ml
@@ -74,7 +74,7 @@ let rec gentest : type a. a typ -> a list =
       match n with
       | 0 -> acc
       | n ->
-        let field_get : type a. string -> a typ -> (a, Rresult.R.msg) Result.result =
+        let field_get : type a. string -> a typ -> (a, Rresult.R.msg) Result.t =
          fun _ ty ->
           let vs = gentest ty in
           Result.Ok (List.nth vs (Random.int (List.length vs)))
@@ -169,7 +169,7 @@ let rec genall : type a. int -> string -> a typ -> a list =
     in
     List.map
       (fun combination ->
-        let field_get : type a. string -> a typ -> (a, Rresult.R.msg) Result.result =
+        let field_get : type a. string -> a typ -> (a, Rresult.R.msg) Result.t =
          fun fname ty ->
           let n = List.assoc fname combination in
           let vs = genall (depth - 1) fname ty in
@@ -222,7 +222,7 @@ let rec gen_nice : type a. a typ -> string -> a =
   | Tuple4 (x, y, z, a) ->
     gen_nice x (narg 1), gen_nice y (narg 2), gen_nice z (narg 3), gen_nice a (narg 4)
   | Struct { constructor; _ } ->
-    let field_get : type a. string -> a typ -> (a, Rresult.R.msg) Result.result =
+    let field_get : type a. string -> a typ -> (a, Rresult.R.msg) Result.t =
      fun name ty -> Result.Ok (gen_nice ty name)
     in
     (match constructor { field_get } with

--- a/src/lib/rpcmarshal.ml
+++ b/src/lib/rpcmarshal.ml
@@ -5,7 +5,7 @@ type err = [ `Msg of string ]
 
 let tailrec_map f l = List.rev_map f l |> List.rev
 
-let rec unmarshal : type a. a typ -> Rpc.t -> (a, err) Result.result =
+let rec unmarshal : type a. a typ -> Rpc.t -> (a, err) Result.t =
  fun t v ->
   let open Rpc in
   let open Result in
@@ -107,7 +107,7 @@ let rec unmarshal : type a. a typ -> Rpc.t -> (a, err) Result.result =
       let keys = List.map (fun (s, v) -> String.lowercase_ascii s, v) keys' in
       constructor
         { field_get =
-            (let x : type a. string -> a typ -> (a, Rresult.R.msg) Result.result =
+            (let x : type a. string -> a typ -> (a, Rresult.R.msg) Result.t =
               fun s ty ->
                let s = String.lowercase_ascii s in
                match ty with

--- a/src/lwt/rpc_lwt.mli
+++ b/src/lwt/rpc_lwt.mli
@@ -3,7 +3,7 @@ type server_implementation
 
 module T : sig
   type 'a box
-  type ('a, 'b) resultb = ('a, 'b) Result.result box
+  type ('a, 'b) resultb = ('a, 'b) Result.t box
   type rpcfn = Rpc.call -> Rpc.response Lwt.t
 
   val lift : ('a -> 'b Lwt.t) -> 'a -> 'b box

--- a/tests/rpc/test_pythongen.ml
+++ b/tests/rpc/test_pythongen.ml
@@ -91,7 +91,7 @@ let run_linters file =
   run_cmd
     "pylint should exit with 0"
     ("pylint \
-      --disable=line-too-long,too-few-public-methods,unused-argument,no-self-use,invalid-name,broad-except,protected-access,redefined-builtin,useless-object-inheritance,super-with-arguments "
+      --disable=line-too-long,too-few-public-methods,unused-argument,no-self-use,invalid-name,broad-except,protected-access,redefined-builtin,useless-object-inheritance,super-with-arguments,consider-using-f-string "
     ^ file);
   run_cmd "pycodestyle should exit with 0" ("pycodestyle --ignore=W504,E501 " ^ file)
 


### PR DESCRIPTION
This version of rresult drops Result.result, Use Result.t instead

See https://github.com/ocaml/opam-repository/pull/19684