### PR TITLE
Rfc2045 decode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 8.1.2 (February 2022)
 * Add the `noargs` constructor for declaring interfaces that do not take any 
   parameters.
+* Allow Xmlrpc callers to override the base64 decoding function.
 
 ## 8.1.1 (November 2021)
 * Ignore error about using f-strings in python bindings (@psafont)

--- a/src/lib/xmlrpc.ml
+++ b/src/lib/xmlrpc.ml
@@ -313,14 +313,14 @@ module Parser = struct
   let make_float = make (fun data -> Float (float_of_string data))
   let make_string = make (fun data -> String data)
   let make_dateTime = make (fun data -> DateTime data)
-  let make_base64 ?(base64_decode=fun s -> Base64.decode_exn s) =
-    make (fun data -> Base64 (base64_decode data))
+  let make_base64 ?(base64_decoder=fun s -> Base64.decode_exn s) =
+    make (fun data -> Base64 (base64_decoder data))
   let make_enum = make (fun data -> Enum data)
   let make_dict = make (fun data -> Dict data)
 
   (* General parser functions *)
-  let rec of_xml ?callback ?base64_decode accu input =
-    try value (map_tags (basic_types ?callback ?base64_decode accu)) input with
+  let rec of_xml ?callback ?base64_decoder accu input =
+    try value (map_tags (basic_types ?callback ?base64_decoder accu)) input with
     | Xmlm.Error ((a, b), e) as exn ->
       eprintf "Characters %i--%i: %s\n%!" a b (Xmlm.error_message e);
       raise exn
@@ -329,13 +329,13 @@ module Parser = struct
       raise e
 
 
-  and basic_types ?callback ?base64_decode accu input = function
+  and basic_types ?callback ?base64_decoder accu input = function
     | "int" | "i8" | "i4" -> make_int ?callback accu (get_data input)
     | "boolean" -> make_bool ?callback accu (get_data input)
     | "double" -> make_float ?callback accu (get_data input)
     | "string" -> make_string ?callback accu (get_data input)
     | "dateTime.iso8601" -> make_dateTime ?callback accu (get_data input)
-    | "base64" -> make_base64 ?callback ?base64_decode accu (get_data input)
+    | "base64" -> make_base64 ?callback ?base64_decoder accu (get_data input)
     | "array" -> make_enum ?callback accu (data (of_xmls ?callback accu) input)
     | "struct" ->
       make_dict
@@ -360,25 +360,25 @@ module Parser = struct
     List.rev !r
 end
 
-let of_string ?callback ?base64_decode str =
+let of_string ?callback ?base64_decoder str =
   let input = Xmlm.make_input (`String (0, str)) in
   (match Xmlm.peek input with
   | `Dtd _ -> ignore (Xmlm.input input)
   | _ -> ());
-  Parser.of_xml ?callback ?base64_decode [] input
+  Parser.of_xml ?callback ?base64_decoder [] input
 
 
-let of_a ?callback ?base64_decode ~next_char b =
+let of_a ?callback ?base64_decoder ~next_char b =
   let aux () =
     match next_char b with
     | Some c -> int_of_char c
     | None -> raise End_of_file
   in
   let input = Xmlm.make_input (`Fun aux) in
-  Parser.of_xml ?callback ?base64_decode [] input
+  Parser.of_xml ?callback ?base64_decoder [] input
 
 
-let call_of_string ?callback ?base64_decode str =
+let call_of_string ?callback ?base64_decoder str =
   let input = Xmlm.make_input (`String (0, str)) in
   (match Xmlm.peek input with
   | `Dtd _ -> ignore (Xmlm.input input)
@@ -397,7 +397,7 @@ let call_of_string ?callback ?base64_decode str =
             Parser.map_tag
               "param"
               (fun input -> params :=
-                Parser.of_xml ?callback ?base64_decode [] input :: !params)
+                Parser.of_xml ?callback ?base64_decoder [] input :: !params)
               input;
             Parser.skip_empty input
           done)
@@ -406,11 +406,11 @@ let call_of_string ?callback ?base64_decode str =
   call !name (List.rev !params)
 
 
-let response_of_fault ?callback ?base64_decode input =
+let response_of_fault ?callback ?base64_decoder input =
   Parser.map_tag
     "fault"
     (fun input ->
-      match Parser.of_xml ?callback ?base64_decode [] input with
+      match Parser.of_xml ?callback ?base64_decoder [] input with
       | Dict d ->
         let fault_code = List.assoc "faultCode" d in
         let fault_string = List.assoc "faultString" d in
@@ -419,14 +419,14 @@ let response_of_fault ?callback ?base64_decode input =
     input
 
 
-let response_of_success ?callback ?base64_decode input =
+let response_of_success ?callback ?base64_decoder input =
   Parser.map_tag
     "params"
     (fun input ->
       Parser.map_tag
         "param"
         (fun input ->
-          match Parser.of_xml ?callback ?base64_decode [] input with
+          match Parser.of_xml ?callback ?base64_decoder [] input with
           | Dict d ->
             if List.mem_assoc "Status" d
                && List.assoc "Status" d = String "Success"
@@ -442,7 +442,7 @@ let response_of_success ?callback ?base64_decode input =
     input
 
 
-let response_of_input ?callback ?base64_decode input =
+let response_of_input ?callback ?base64_decoder input =
   (match Xmlm.peek input with
   | `Dtd _ -> ignore (Xmlm.input input)
   | _ -> ());
@@ -452,9 +452,9 @@ let response_of_input ?callback ?base64_decode input =
       Parser.skip_empty input;
       match Xmlm.peek input with
       | `El_start ((_, "params"), _) ->
-          response_of_success ?callback ?base64_decode input
+          response_of_success ?callback ?base64_decoder input
       | `El_start ((_, "fault"), _) ->
-          response_of_fault ?callback ?base64_decode input
+          response_of_fault ?callback ?base64_decoder input
       | `El_start ((_, tag), _) ->
         parse_error (sprintf "open_tag(%s)" tag) "open_tag(fault/params)" input
       | `Data d -> parse_error (String.escaped d) "open_tag(fault/params)" input
@@ -463,11 +463,11 @@ let response_of_input ?callback ?base64_decode input =
     input
 
 
-let response_of_string ?callback ?base64_decode str =
+let response_of_string ?callback ?base64_decoder str =
   let input = Xmlm.make_input (`String (0, str)) in
-  response_of_input ?callback ?base64_decode input
+  response_of_input ?callback ?base64_decoder input
 
 
-let response_of_in_channel ?callback ?base64_decode chan =
+let response_of_in_channel ?callback ?base64_decoder chan =
   let input = Xmlm.make_input (`Channel chan) in
-  response_of_input ?callback ?base64_decode input
+  response_of_input ?callback ?base64_decoder input

--- a/src/lib/xmlrpc.mli
+++ b/src/lib/xmlrpc.mli
@@ -22,22 +22,22 @@ val a_of_response
 
 exception Parse_error of string * string * Xmlm.input
 
-(* The parsing functions make it possible to specify the routine used to
-   decode base64 values. The default is to use [Base64.decode_exn] which
-   strictly interprets the standard. A different function will be required if
-   the XMLRPC server inserts line breaks into the base64 encoding (as per
-   RFC2045). *)
+(** The parsing functions make it possible to specify the routine used to
+    decode base64 values. The default is to use [Base64.decode_exn] which
+    strictly interprets the standard. A different function will be required if
+    the XMLRPC server inserts line breaks into the base64 encoding (as per
+    RFC2045). *)
 
 val pretty_string_of_error : string -> string -> Xmlm.input -> string
 val parse_error : string -> string -> Xmlm.input -> unit
 val of_string
   : ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decode:(string -> string)
+  -> ?base64_decoder:(string -> string)
   -> string -> Rpc.t
 
 val of_a
   :  ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decode:(string -> string)
+  -> ?base64_decoder:(string -> string)
   -> next_char:('b -> char option)
   -> 'b
   -> Rpc.t
@@ -45,35 +45,35 @@ val of_a
 
 val call_of_string
   : ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decode:(string -> string)
+  -> ?base64_decoder:(string -> string)
   -> string -> Rpc.call
 
 val response_of_fault
   :  ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decode:(string -> string)
+  -> ?base64_decoder:(string -> string)
   -> Xmlm.input
   -> Rpc.response
 
 val response_of_success
   :  ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decode:(string -> string)
+  -> ?base64_decoder:(string -> string)
   -> Xmlm.input
   -> Rpc.response
 
 val response_of_input
   :  ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decode:(string -> string)
+  -> ?base64_decoder:(string -> string)
   -> Xmlm.input
   -> Rpc.response
 
 val response_of_string
   :  ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decode:(string -> string)
+  -> ?base64_decoder:(string -> string)
   -> string
   -> Rpc.response
 
 val response_of_in_channel
   :  ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decode:(string -> string)
+  -> ?base64_decoder:(string -> string)
   -> in_channel
   -> Rpc.response

--- a/src/lib/xmlrpc.mli
+++ b/src/lib/xmlrpc.mli
@@ -22,40 +22,58 @@ val a_of_response
 
 exception Parse_error of string * string * Xmlm.input
 
+(* The parsing functions make it possible to specify the routine used to
+   decode base64 values. The default is to use [Base64.decode_exn] which
+   strictly interprets the standard. A different function will be required if
+   the XMLRPC server inserts line breaks into the base64 encoding (as per
+   RFC2045). *)
+
 val pretty_string_of_error : string -> string -> Xmlm.input -> string
 val parse_error : string -> string -> Xmlm.input -> unit
-val of_string : ?callback:(string list -> Rpc.t -> unit) -> string -> Rpc.t
+val of_string
+  : ?callback:(string list -> Rpc.t -> unit)
+  -> ?base64_decode:(string -> string)
+  -> string -> Rpc.t
 
 val of_a
   :  ?callback:(string list -> Rpc.t -> unit)
+  -> ?base64_decode:(string -> string)
   -> next_char:('b -> char option)
   -> 'b
   -> Rpc.t
   [@@ocaml.deprecated]
 
-val call_of_string : ?callback:(string list -> Rpc.t -> unit) -> string -> Rpc.call
+val call_of_string
+  : ?callback:(string list -> Rpc.t -> unit)
+  -> ?base64_decode:(string -> string)
+  -> string -> Rpc.call
 
 val response_of_fault
   :  ?callback:(string list -> Rpc.t -> unit)
+  -> ?base64_decode:(string -> string)
   -> Xmlm.input
   -> Rpc.response
 
 val response_of_success
   :  ?callback:(string list -> Rpc.t -> unit)
+  -> ?base64_decode:(string -> string)
   -> Xmlm.input
   -> Rpc.response
 
 val response_of_input
   :  ?callback:(string list -> Rpc.t -> unit)
+  -> ?base64_decode:(string -> string)
   -> Xmlm.input
   -> Rpc.response
 
 val response_of_string
   :  ?callback:(string list -> Rpc.t -> unit)
+  -> ?base64_decode:(string -> string)
   -> string
   -> Rpc.response
 
 val response_of_in_channel
   :  ?callback:(string list -> Rpc.t -> unit)
+  -> ?base64_decode:(string -> string)
   -> in_channel
   -> Rpc.response


### PR DESCRIPTION
Some XML-RPC servers break Base64 encoded data into lines of 76 characters long (see, e.g., the [Python xmlrpc](https://docs.python.org/3/library/xmlrpc.client.html#xmlrpc.client.Binary.encode) library). In these cases the `Base64.decode_exn` function raises an exception `Invalid_argument "Malformed input"`.

I propose, in this pull request, to decode using the `Base64_rfc2045` module which handles newlines. This module also decodes base64 strings without line breaks (in "dangerous" mode) and thus supports existing behavior.