### PR TITLE
Rpc_genfake.{gentest,genall}: avoid crash on recursive types

### DIFF
--- a/src/lib/rpc_genfake.ml
+++ b/src/lib/rpc_genfake.ml
@@ -13,8 +13,6 @@ end
 
 module Seen = Set.Make(SeenType)
 
-(* don't use this on recursive types! *)
-
 let rec gentest : type a. Seen.t -> a typ -> a list =
  fun seen t ->
   let seen_t = SeenType.T t in
@@ -259,5 +257,7 @@ let rec gen_nice : type a. a typ -> string -> a =
       v.treview content)
   | Abstract { test_data; _ } -> List.hd test_data
 
+(** don't use this on recursive types! *)
 let gentest t = gentest Seen.empty t
+
 let genall t = genall Seen.empty t

--- a/tests/ppx/test_deriving_rpcty.ml
+++ b/tests/ppx/test_deriving_rpcty.ml
@@ -312,6 +312,11 @@ type nested =
   }
 [@@deriving rpcty]
 
+type recursive =
+  | A of recursive * string
+  | B of int
+[@@deriving rpcty]
+
 let fakegen () =
   let fake ty =
     let fake = Rpc_genfake.genall 10 "string" ty in
@@ -335,7 +340,8 @@ let fakegen () =
   in
   fake typ_of_test_record_opt;
   fake typ_of_test_variant_name;
-  fake typ_of_nested
+  fake typ_of_nested;
+  fake typ_of_recursive
 
 
 type test_defaults = { test_with_default : int [@default 5] } [@@deriving rpcty]


### PR DESCRIPTION
I was trying to define some nice recursive types, but the test generator ended up using a lot of memory, until the system started swapping (and I assume it would've eventually gotten OOM killed). 

Attempting to call 'genall' on a recursive type would either result in an OOM kill, because it'd recurse infinitely trying to generate testcases. When recursion depth is negative return the empty list instead of generating recursively and taking the first.

There are more things to fix here, because although the testcase I added here now works, the original type(s) that I created still OOM trying to generate stacks (but stack depth seems fine).