### PR TITLE
Rpc_genfake: introduce maxcomb to limit number of combinations

### DIFF
--- a/src/lib/rpc_genfake.ml
+++ b/src/lib/rpc_genfake.ml
@@ -82,15 +82,15 @@ let rec gentest : type a. Seen.t -> a typ -> a Seq.t =
           v.treview content)
   | Abstract { test_data; _ } -> test_data |> List.to_seq
 
-let thin d result =
-  if d < 0 then Seq.take 1 result else result
-
-let rec genall: type a. Seen.t -> int -> string -> a typ -> a Seq.t =
- fun seen depth strhint t ->
+let rec genall: type a. maxcomb:int -> Seen.t -> int -> string -> a typ -> a Seq.t =
+ fun ~maxcomb seen depth strhint t ->
+  let thin d result =
+    if d < 0 then Seq.take 1 result else Seq.take maxcomb result
+  in
   let seen_t = SeenType.T t in
   if Seen.mem seen_t seen then Seq.empty
   else
-  let genall depth strhint t = genall (Seen.add seen_t seen) depth strhint t in
+  let genall depth strhint t = genall ~maxcomb (Seen.add seen_t seen) depth strhint t in
   match t with
   | Basic Int -> Seq.return 0
   | Basic Int32 -> Seq.return 0l
@@ -219,5 +219,4 @@ let rec gen_nice : type a. a typ -> string -> a =
 
 (** don't use this on recursive types! *)
 let gentest t = gentest Seen.empty t |> List.of_seq
-
-let genall depth strhint t = genall Seen.empty depth strhint t |> List.of_seq
+let genall ?(maxcomb=Sys.max_array_length) depth strhint t = genall ~maxcomb Seen.empty depth strhint t |> List.of_seq


### PR DESCRIPTION
Now we no longer run out of memory trying to generate tests for `Xenops_interface` with `maxcomb:100` or `maxcomb:1000`.
This builds on top of https://github.com/mirage/ocaml-rpc/pull/176

Still TODO: `gen_nice` still dies on recursive datatypes, which prevent generating documentation in some cases, noticed by @psafont , but I'll leave that for yet another PR (it is not obvious how to limit it there, because it must return a type 'a', so likely we need to perform the 'seen' check before making the call)