### PR TITLE
Fix python cmdline parser for variants

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Cache pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         # windows-latest async does not support it for now
         operating-system: [macos-latest, ubuntu-latest]
-        ocaml-version: [ '4.14.0', '4.08.1' ]
+        ocaml-version: [ '5.2.0', '4.14.0' ]
     steps:
     - uses: actions/checkout@master
     - name: Setup Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install Python dependencies
       run: pip install pylint pycodestyle
     - name: Install OCaml
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: ${{ matrix.ocaml-version }}
     - name: Install OCaml dependencies

--- a/src/lib/pythongen.ml
+++ b/src/lib/pythongen.ml
@@ -699,6 +699,7 @@ let commandline_parse _ (BoxedFunction m) =
                    | Basic Int32 -> ", type=int"
                    | Basic Bool -> ", type=lambda x: json.loads(x.lower())"
                    | Basic Float -> ", type=float"
+                   | Variant _ -> ", type=json.loads"
                    | _ -> "")))
           inputs
       @ [ Line "return vars(parser.parse_args())" ])

--- a/src/lib/pythongen.ml
+++ b/src/lib/pythongen.ml
@@ -98,8 +98,9 @@ class ListAction(argparse.Action):
 
 let compat_block =
   [ Line "get_str = str"
-  ; Line "if sys.version_info[0] > 2:"
-  ; Block [ Line "long = int"; Line "unicode = str"; Line "str = bytes" ]
+  ; Line "long = int"
+  ; Line "unicode = str"
+  ; Line "str = bytes"
   ; Line ""
   ]
 


### PR DESCRIPTION
Given
```
type operation = Copy of string | Mirror of string
```

Represented as `["Copy", "arg"]` we need to parse that as JSON when given on the cmdline.

Otherwise it'd do `operation[0]`, where `operation` is a string, which is not what we want.

This doesn't affect usage from xapi-storage-script (which always calls it with --json),
but it affects testing the python code by hand, because you can't supply the correct cmdline arguments
(unless you construct an entire JSON by hand and pass it on stdin which is a bit tedious)