### PR TITLE
Ppxlib 5.2 AST bump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         # windows-latest async does not support it for now
         operating-system: [macos-latest, ubuntu-latest]
-        ocaml-version: [ '5.2.0', '4.14.0' ]
+        ocaml-version: [ '5.3.0', '5.2.0', '4.14.2' ]
     steps:
     - uses: actions/checkout@master
     - name: Setup Python
@@ -33,10 +33,16 @@ jobs:
       with:
         ocaml-compiler: ${{ matrix.ocaml-version }}
     - name: Install OCaml dependencies
-      run: opam install -t . --deps-only
+      run: opam install -t ./ppx_deriving_rpc.opam ./rpclib-html.opam ./rpclib-js.opam ./rpclib-lwt.opam ./rpclib.opam --deps-only
     - name: Build and test independently
-      run: opam install -t rpclib rpclib-js rpclib-html rpclib-lwt rpclib-async
+      run: opam install -t rpclib rpclib-js rpclib-html rpclib-lwt
     - name: Run Rpc and Ppx_deriving_rpc Tests
       run: opam exec -- dune runtest -p ppx_deriving_rpc
     - name: Build and run Examples
       run: opam exec -- dune build @runexamples -p ppx_deriving_rpc
+    - if: ${{ matrix.ocaml-version >= '5.3.0' }}
+      name: Install OCaml dependencies (Async)
+      run: opam install -t ./rpclib-async.opam --deps-only
+    - if: ${{ matrix.ocaml-version >= '5.3.0' }}
+      name: Build and test independently (Async)
+      run: opam install -t rpclib-async

--- a/ppx/ppx_deriving_rpc.ml
+++ b/ppx/ppx_deriving_rpc.ml
@@ -239,6 +239,7 @@ module Of_rpc = struct
     | { ptyp_desc = Ptyp_alias (_, _); _ } -> failwith "Ptyp_alias not handled"
     | { ptyp_desc = Ptyp_class (_, _); _ } -> failwith "Ptyp_class not handled"
     | { ptyp_desc = Ptyp_package _; _ } -> failwith "Ptyp_package not handled"
+    | { ptyp_desc = Ptyp_open _; _ } -> failwith "Ptyp_open not handled"
 
 
   let str_of_type ~loc type_decl =
@@ -393,7 +394,7 @@ module Of_rpc = struct
         [%expr
           fun rpc ->
             let rpc' = Rpc.lowerfn rpc in
-            [%e pexp_function (cases @ [ default ])] rpc']
+            [%e pexp_function_cases (cases @ [ default ])] rpc']
     in
     of_rpc
 end
@@ -523,7 +524,7 @@ module Rpc_of = struct
                | _ -> failwith "cannot be derived for")
         |> List.rev
       in
-      pexp_function cases
+      pexp_function_cases cases
     | { ptyp_desc = Ptyp_any; _ } -> failwith "Ptyp_any not handled"
     | { ptyp_desc = Ptyp_var name; _ } -> [%expr [%e evar ("poly_" ^ name)]]
     | { ptyp_desc = Ptyp_poly (_, _); _ } -> failwith "Ptyp_poly not handled"
@@ -533,6 +534,7 @@ module Rpc_of = struct
     | { ptyp_desc = Ptyp_alias (_, _); _ } -> failwith "Ptyp_alias not handled"
     | { ptyp_desc = Ptyp_class (_, _); _ } -> failwith "Ptyp_class not handled"
     | { ptyp_desc = Ptyp_package _; _ } -> failwith "Ptyp_package not handled"
+    | { ptyp_desc = Ptyp_open _; _ } -> failwith "Ptyp_open not handled"
 
 
   (*  | _ -> failwith "Error"*)
@@ -625,7 +627,7 @@ module Rpc_of = struct
                  | Pcstr_record _ -> failwith "record variants are not supported")
           |> List.rev
         in
-        pexp_function cases
+        pexp_function_cases cases
     in
     to_rpc
 end

--- a/ppx/ppx_deriving_rpcty.ml
+++ b/ppx/ppx_deriving_rpcty.ml
@@ -55,6 +55,7 @@ module Typ_of = struct
       | { ptyp_desc = Ptyp_alias (_, _); _ } -> failwith "Ptyp_alias not handled"
       | { ptyp_desc = Ptyp_class (_, _); _ } -> failwith "Ptyp_class not handled"
       | { ptyp_desc = Ptyp_package _; _ } -> failwith "Ptyp_package not handled"
+      | { ptyp_desc = Ptyp_open _; _ } -> failwith "Ptyp_open not handled"
     in
     expr
 
@@ -269,7 +270,7 @@ module Typ_of = struct
             else [ case ~guard:None ~lhs:ppat_any ~rhs:[%expr None] ]
           in
           let vpreview =
-            pexp_function
+            pexp_function_cases
               ([ case
                    ~lhs:(ppat_construct (Located.mk (lident cname)) pat)
                    ~guard:None
@@ -277,7 +278,7 @@ module Typ_of = struct
                ]
               @ vpreview_default)
           in
-          let vreview = pexp_function [ case ~lhs:pat' ~guard:None ~rhs:constr ] in
+          let vreview = pexp_function_cases [ case ~lhs:pat' ~guard:None ~rhs:constr ] in
           let variant =
             [%expr
               BoxedTag
@@ -304,7 +305,7 @@ module Typ_of = struct
                   Rresult.R.bind
                     (t.tget [%e contents])
                     [%e
-                      pexp_function
+                      pexp_function_cases
                         [ case ~lhs:pat' ~guard:None ~rhs:[%expr Rresult.R.ok [%e constr]]
                         ]]]
           in

--- a/ppx_deriving_rpc.opam
+++ b/ppx_deriving_rpc.opam
@@ -12,7 +12,7 @@ depends: [
   "dune" {>= "2.0.0"}
   "rpclib" {= version}
   "rresult" {>= "0.3.0"}
-  "ppxlib" {>= "0.18.0"}
+  "ppxlib" {>= "0.36.0"}
   "lwt" {with-test & >= "3.0.0"}
   "alcotest" {with-test}
 ]

--- a/rpclib-async.opam
+++ b/rpclib-async.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/ocaml-rpc/rpclib-async"
 bug-reports: "https://github.com/mirage/ocaml-rpc/issues"
 license: "ISC"
 depends: [
-  "ocaml"
+  "ocaml" { >= "5.3.0" }
   "alcotest" {with-test}
   "dune" {>= "2.0.0"}
   "rpclib" {=version}


### PR DESCRIPTION
This PR is a patch for an upcoming release of ppxlib where the internal AST is [bumped from 4.14 to 5.2](https://github.com/ocaml-ppx/ppxlib/pull/514). Until that is merged and released, there is no reason to merge this PR.

To test these changes, you can use the following opam-based workflow. I've made releases of most of these patches to an opam-repository overlay.

```shell
opam switch create ppxlib-bump --repos=ppxlib=git+https://github.com/patricoferris/opam-repository#5.2-ast-bump
opam install <your-package>
```

The following describes the most notable changes to the AST.

### Functions
---

#### Currently 

In the parsetree currently, functions like:

```ocaml
fun x y z -> ...
```

Are represented roughly as

```ocaml
Pexp_fun(x, Pexp_fun (y, Pexp_fun(z, ...)))
```

Functions like:

```ocaml
function A -> ... | B -> ...
```

Are represented roughly as

```ocaml
Pexp_function ([ case A; case B ])
```

#### Since 5.2

All of these functions now map to a single AST node `Pexp_function` (note, this is the same name as the old cases function). The first argument is a list of parameters meaning:

```ocaml
fun x y z -> ...
```

Now looks like:

```ocaml
Pexp_function([x; y; z], _constraint, body)
```

And the `body` is where we can either have _more_ expressions (`Pfunction_body _`) or cases (`Pfunction_cases _`). That means:

```ocaml
function A -> ... | B -> ...
```

Has an empty list of parameters:

```ocaml
Pexp_function([], _, Pfunction_cases ([case A; case B]))
```

### Local Module Opens for Types

Another feature added in 5.2 was the ability to locally open modules in type definitions. 

```ocaml
module M = struct
  type t = A | B | C
end

type t = Local_open_coming of M.(t)
```

This has a `Ptyp_open (module_identifier, core_type)` AST node. Just like normal module opens this does create some syntactic ambiguity about where things come from inside the parentheses. The approach of these patches is to locally open the same module in any code that is generated.

This PR assumes `ppxlib.0.35.0` will be the ppxlib that contains the 5.2 AST bump. `ppxlib.0.34.0` will likely be the stable release of ppxlib with 5.3 support.