### PR TITLE
Optimize XMLRPC

### DIFF
--- a/src/lib/xmlrpc.ml
+++ b/src/lib/xmlrpc.ml
@@ -14,78 +14,111 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
-
 open Printf
 open Rpc
 
 (* marshalling/unmarshalling code *)
+
+let gt = "&gt;"
+let lt = "&lt;"
+let amp = "&amp;"
+let quot = "&quot;"
+let nil = ""
+
+(* encode: for backwards compat only, unused *)
+
 (* The XML-RPC is not very clear about what characters can be in a string value ... *)
 let encode =
   let translate = function
-    | '>' -> Some "&gt;"
-    | '<' -> Some "&lt;"
-    | '&' -> Some "&amp;"
-    | '"' -> Some "&quot;"
+    | '>' -> Some gt
+    | '<' -> Some lt
+    | '&' -> Some amp
+    | '"' -> Some quot
     | c when (c >= '\x20' && c <= '\xff') || c = '\x09' || c = '\x0a' || c = '\x0d' ->
       None
-    | _ -> Some ""
+    | _ -> Some nil
   in
   Internals.encode translate
 
 
-let rec add_value ?(strict = false) f = function
-  | Null -> f "<value><nil/></value>"
+let[@inline always] encode_add buf s m ~i n =
+  Buffer.add_substring buf s m (i - m);
+  Buffer.add_string buf n;
+  i + 1
+
+
+(** Encodes a string using the given translation function that maps a character
+    to a string that is its encoded version, if that character needs encoding. *)
+let[@inline always] encode_buf buf s =
+  let n = String.length s in
+  let m = ref 0 in
+  (* do not let the ref escape, better optimizations *)
+  for i = 0 to n - 1 do
+    (* The XML-RPC is not very clear about what characters can be in a string value ... *)
+    match String.unsafe_get s i with
+    | '>' -> m := encode_add buf s !m ~i "&gt;"
+    | '<' -> m := encode_add buf s !m ~i "&lt;"
+    | '&' -> m := encode_add buf s !m ~i "&amp;"
+    | '"' -> m := encode_add buf s !m ~i "&quot;"
+    | '\x20' .. '\xff' | '\x09' | '\x0a' | '\x0d' -> ()
+    | _ -> m := encode_add buf s !m ~i ""
+  done;
+  Buffer.add_substring buf s !m (n - !m)
+
+
+let rec add_value ~strict buf = function
+  | Null -> Buffer.add_string buf "<value><nil/></value>"
   | Int i ->
-    f "<value>";
-    if strict then f "<i8>";
-    f (Int64.to_string i);
-    if strict then f "</i8>";
-    f "</value>"
+    Buffer.add_string buf "<value>";
+    if strict then Buffer.add_string buf "<i8>";
+    Printf.bprintf buf "%Ld" i;
+    if strict then Buffer.add_string buf "</i8>";
+    Buffer.add_string buf "</value>"
   | Int32 i ->
-    f "<value><i4>";
-    f (Int32.to_string i);
-    f "</i4></value>"
+    Buffer.add_string buf "<value><i4>";
+    Printf.bprintf buf "%ld" i;
+    Buffer.add_string buf "</i4></value>"
   | Bool b ->
-    f "<value><boolean>";
-    f (if b then "1" else "0");
-    f "</boolean></value>"
+    Buffer.add_string buf "<value><boolean>";
+    Buffer.add_string buf (if b then "1" else "0");
+    Buffer.add_string buf "</boolean></value>"
   | Float d ->
-    f "<value><double>";
+    Buffer.add_string buf "<value><double>";
     (* NB: "%g" loses a lot of precision (e.g. resulting in "1.32621e+09") *)
-    f (Printf.sprintf "%.16g" d);
-    f "</double></value>"
+    Printf.bprintf buf "%.16g" d;
+    Buffer.add_string buf "</double></value>"
   | String s ->
-    f "<value>";
-    f (encode s);
-    f "</value>"
+    Buffer.add_string buf "<value>";
+    encode_buf buf s;
+    Buffer.add_string buf "</value>"
   | DateTime s ->
-    f "<value><dateTime.iso8601>";
-    f s;
-    f "</dateTime.iso8601></value>"
+    Buffer.add_string buf "<value><dateTime.iso8601>";
+    Buffer.add_string buf s;
+    Buffer.add_string buf "</dateTime.iso8601></value>"
   | Base64 s ->
-    f "<value><base64>";
-    f (Base64.encode_exn s);
-    f "</base64></value>"
+    Buffer.add_string buf "<value><base64>";
+    Buffer.add_string buf (Base64.encode_exn s);
+    Buffer.add_string buf "</base64></value>"
   | Enum l ->
-    f "<value><array><data>";
-    List.iter (add_value ~strict f) l;
-    f "</data></array></value>"
+    Buffer.add_string buf "<value><array><data>";
+    List.iter (add_value ~strict buf) l;
+    Buffer.add_string buf "</data></array></value>"
   | Dict d ->
     let add_member (name, value) =
-      f "<member><name>";
-      f name;
-      f "</name>";
-      add_value ~strict f value;
-      f "</member>"
+      Buffer.add_string buf "<member><name>";
+      Buffer.add_string buf name;
+      Buffer.add_string buf "</name>";
+      add_value ~strict buf value;
+      Buffer.add_string buf "</member>"
     in
-    f "<value><struct>";
+    Buffer.add_string buf "<value><struct>";
     List.iter add_member d;
-    f "</struct></value>"
+    Buffer.add_string buf "</struct></value>"
 
 
 let to_string ?(strict = false) x =
   let buf = Buffer.create 128 in
-  add_value ~strict (Buffer.add_string buf) x;
+  add_value ~strict buf x;
   Buffer.contents buf
 
 
@@ -95,34 +128,33 @@ let string_of_call ?(strict = false) call =
   let add = B.add_string buf in
   add "<?xml version=\"1.0\"?>";
   add "<methodCall><methodName>";
-  add (encode call.name);
+  encode_buf buf call.name;
   add "</methodName><params>";
   List.iter
     (fun p ->
        add "<param>";
-       add (to_string ~strict p);
+       add_value ~strict buf p;
        add "</param>")
     call.params;
   add "</params></methodCall>";
   B.contents buf
 
 
-let add_response ?(strict = false) add response =
+let add_response ?(strict = false) buf response =
   let v =
     if response.success
     then Dict [ "Status", String "Success"; "Value", response.contents ]
     else Dict [ "Status", String "Failure"; "ErrorDescription", response.contents ]
   in
-  add "<?xml version=\"1.0\"?><methodResponse><params><param>";
-  add_value ~strict add v;
-  add "</param></params></methodResponse>"
+  Buffer.add_string buf "<?xml version=\"1.0\"?><methodResponse><params><param>";
+  add_value ~strict buf v;
+  Buffer.add_string buf "</param></params></methodResponse>"
 
 
 let string_of_response ?(strict = false) response =
   let module B = Buffer in
   let buf = B.create 256 in
-  let add = B.add_string buf in
-  add_response ~strict add response;
+  add_response ~strict buf response;
   B.contents buf
 
 

--- a/src/lib/xmlrpc.ml
+++ b/src/lib/xmlrpc.ml
@@ -89,12 +89,6 @@ let to_string ?(strict = false) x =
   Buffer.contents buf
 
 
-let to_a ?(strict = false) ~empty ~append x =
-  let buf = empty () in
-  add_value ~strict (fun s -> append buf s) x;
-  buf
-
-
 let string_of_call ?(strict = false) call =
   let module B = Buffer in
   let buf = B.create 1024 in
@@ -120,7 +114,7 @@ let add_response ?(strict = false) add response =
     else Dict [ "Status", String "Failure"; "ErrorDescription", response.contents ]
   in
   add "<?xml version=\"1.0\"?><methodResponse><params><param>";
-  to_a ~strict ~empty:(fun () -> ()) ~append:(fun _ s -> add s) v;
+  add_value ~strict add v;
   add "</param></params></methodResponse>"
 
 
@@ -130,13 +124,6 @@ let string_of_response ?(strict = false) response =
   let add = B.add_string buf in
   add_response ~strict add response;
   B.contents buf
-
-
-let a_of_response ?(strict = false) ~empty ~append response =
-  let buf = empty () in
-  let add s = append buf s in
-  add_response ~strict add response;
-  buf
 
 
 exception Parse_error of string * string * Xmlm.input
@@ -369,16 +356,6 @@ let of_string ?callback ?base64_decoder str =
   (match Xmlm.peek input with
    | `Dtd _ -> ignore (Xmlm.input input)
    | _ -> ());
-  Parser.of_xml ?callback ?base64_decoder [] input
-
-
-let of_a ?callback ?base64_decoder ~next_char b =
-  let aux () =
-    match next_char b with
-    | Some c -> int_of_char c
-    | None -> raise End_of_file
-  in
-  let input = Xmlm.make_input (`Fun aux) in
   Parser.of_xml ?callback ?base64_decoder [] input
 
 

--- a/src/lib/xmlrpc.mli
+++ b/src/lib/xmlrpc.mli
@@ -1,24 +1,7 @@
 val encode : string -> string [@@ocaml.deprecated]
 val to_string : ?strict:bool -> Rpc.t -> string
-
-val to_a
-  :  ?strict:bool
-  -> empty:(unit -> 'a)
-  -> append:('a -> string -> unit)
-  -> Rpc.t
-  -> 'a
-[@@ocaml.deprecated]
-
 val string_of_call : ?strict:bool -> Rpc.call -> string
 val string_of_response : ?strict:bool -> Rpc.response -> string
-
-val a_of_response
-  :  ?strict:bool
-  -> empty:(unit -> 'a)
-  -> append:('a -> string -> unit)
-  -> Rpc.response
-  -> 'a
-[@@ocaml.deprecated]
 
 exception Parse_error of string * string * Xmlm.input
 
@@ -36,14 +19,6 @@ val of_string
   -> ?base64_decoder:(string -> string)
   -> string
   -> Rpc.t
-
-val of_a
-  :  ?callback:(string list -> Rpc.t -> unit)
-  -> ?base64_decoder:(string -> string)
-  -> next_char:('b -> char option)
-  -> 'b
-  -> Rpc.t
-[@@ocaml.deprecated]
 
 val call_of_string
   :  ?callback:(string list -> Rpc.t -> unit)

--- a/src/lib/xmlrpc.mli
+++ b/src/lib/xmlrpc.mli
@@ -1,4 +1,4 @@
-val encode : string -> string
+val encode : string -> string [@@ocaml.deprecated]
 val to_string : ?strict:bool -> Rpc.t -> string
 
 val to_a


### PR DESCRIPTION
This is still used by default for communication between XAPI and SMAPIv1 SM. Although we should switch that to JSON, it is not trivial because there isn't a drop-in JSONRPC library for Python that'd match the XMLRPC interface.

Meanwhile optimize the encoder based on flamegraphs and the benchmark in this repo.

Speeds up xmlrpc encoding ~1.7x in my tests:
```
│  rpc/to_string/xmlrpc   │         15137.2164 mjw/run│           510.7109 mnw/run│         163187.9463 ns/run│
│  rpc/to_string/xmlrpc   │         15137.0650 mjw/run│           627.5495 mnw/run│          94844.6315 ns/run│
```

Draft, because I need to do some wider scale testing .on this