### PR TITLE
CI: move to actions-cache@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip


### PR DESCRIPTION
actions-cache@v2 fails with an error message that we need to update to v3 or v4.