### PR TITLE
Fix JsonRPC on 32-bit platforms

### DIFF
--- a/src/lib/jsonrpc.ml
+++ b/src/lib/jsonrpc.ml
@@ -40,7 +40,7 @@ type version =
 let rec rpc_to_json t =
   match t with
   | Int i -> `Intlit (Int64.to_string i)
-  | Int32 i -> `Int (Int32.to_int i)
+  | Int32 i -> `Intlit (Int32.to_string i)
   | Bool b -> `Bool b
   | Float r -> `Float r
   | String s -> `String s


### PR DESCRIPTION
Converting to int would lose bits when the value is Int32.min_int